### PR TITLE
[COREVM-98] Fix include orders

### DIFF
--- a/include/dyobj/common.h
+++ b/include/dyobj/common.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/include/dyobj/dynamic_object.h
+++ b/include/dyobj/dynamic_object.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,15 +23,17 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_DYNAMIC_OBJECT_H_
 #define COREVM_DYNAMIC_OBJECT_H_
 
-#include <algorithm>
-#include <unordered_map>
-#include <boost/format.hpp>
-#include <sneaker/libc/utils.h>
 #include "common.h"
 #include "dyobj_id.h"
 #include "dyobj_id_helper.h"
 #include "flags.h"
 #include "errors.h"
+
+#include <boost/format.hpp>
+#include <sneaker/libc/utils.h>
+
+#include <algorithm>
+#include <unordered_map>
 
 
 namespace corevm {

--- a/include/dyobj/dynamic_object_heap.h
+++ b/include/dyobj/dynamic_object_heap.h
@@ -23,17 +23,17 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_DYNAMIC_OBJECT_HEAP_H_
 #define COREVM_DYNAMIC_OBJECT_HEAP_H_
 
-#include <algorithm>
-#include <stdexcept>
-#include "../memory/errors.h"
-#include "../memory/object_container.h"
-#include "../memory/sequential_allocation_scheme.h"
 #include "common.h"
 #include "dyobj_id.h"
 #include "dynamic_object.h"
 #include "errors.h"
 #include "heap_allocator.h"
+#include "../memory/errors.h"
+#include "../memory/object_container.h"
+#include "../memory/sequential_allocation_scheme.h"
 
+#include <algorithm>
+#include <stdexcept>
 
 namespace corevm {
 

--- a/include/dyobj/dynamic_object_manager.h
+++ b/include/dyobj/dynamic_object_manager.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/include/dyobj/dynamic_object_manager.h
+++ b/include/dyobj/dynamic_object_manager.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2015 Yanzheng Li
+Copyright (c) 2014 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/include/dyobj/dyobj_id.h
+++ b/include/dyobj/dyobj_id.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -24,6 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define COREVM_DYOBJ_ID_H_
 
 #include <climits>
+#include <cstdint>
 
 
 namespace corevm {
@@ -40,7 +41,7 @@ const uint64_t DYOBJ_LIMIT = ULLONG_MAX;
 
 inline dyobj_id obj_ptr_to_id(void* ptr)
 {
-  return static_cast<dyobj_id>( (char*)(ptr) - (char*)(NULL) );
+  return static_cast<dyobj_id>( (char*)(ptr) - (char*)(0) );
 }
 
 

--- a/include/dyobj/dyobj_id_helper.h
+++ b/include/dyobj/dyobj_id_helper.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,9 +23,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_DYOBJ_ID_HELPER_H_
 #define COREVM_DYOBJ_ID_HELPER_H_
 
-#include <string>
-#include <sneaker/atomic/atomic_incrementor.h>
 #include "dyobj_id.h"
+
+#include <sneaker/atomic/atomic_incrementor.h>
+
+#include <string>
 
 
 namespace corevm {

--- a/include/dyobj/errors.h
+++ b/include/dyobj/errors.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,12 +23,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_DYOBJ_ERRORS_H_
 #define COREVM_DYOBJ_ERRORS_H_
 
-#include <string>
-#include <boost/format.hpp>
 #include "common.h"
 #include "dyobj_id.h"
 #include "dyobj_id_helper.h"
 #include "../errors.h"
+
+#include <boost/format.hpp>
+
+#include <string>
 
 
 namespace corevm {

--- a/include/dyobj/flags.h
+++ b/include/dyobj/flags.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/include/dyobj/flags.h
+++ b/include/dyobj/flags.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2015 Yanzheng Li
+Copyright (c) 2014 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/include/frontend/errors.h
+++ b/include/frontend/errors.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,9 +23,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_FRONTEND_ERRORS_H_
 #define COREVM_FRONTEND_ERRORS_H_
 
-#include <string>
-#include <boost/format.hpp>
 #include "../errors.h"
+
+#include <boost/format.hpp>
+
+#include <string>
 
 
 namespace corevm {

--- a/include/frontend/loader.h
+++ b/include/frontend/loader.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,10 +23,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_FRONTEND_LOADER_H_
 #define COREVM_FRONTEND_LOADER_H_
 
-#include <string>
-#include <sneaker/json/json.h>
 #include "bytecode_runner.h"
 #include "errors.h"
+
+#include <sneaker/json/json.h>
+
+#include <string>
 
 
 namespace corevm {

--- a/include/gc/garbage_collector.h
+++ b/include/gc/garbage_collector.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,8 +23,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_GARBAGE_COLLECTOR_H_
 #define COREVM_GARBAGE_COLLECTOR_H_
 
-#include <algorithm>
 #include "../dyobj/dynamic_object_heap.h"
+
+#include <algorithm>
 
 
 namespace corevm {

--- a/include/memory/allocation_scheme.h
+++ b/include/memory/allocation_scheme.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -22,6 +22,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #ifndef COREVM_ALLOCATION_SCHEME_H_
 #define COREVM_ALLOCATION_SCHEME_H_
+
+#include <cstdlib>
 
 
 namespace corevm {

--- a/include/memory/allocator.h
+++ b/include/memory/allocator.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,12 +23,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_MEMORY_ALLOCATOR_H_
 #define COREVM_MEMORY_ALLOCATOR_H_
 
-
 #include <cassert>
 #include <cstddef>
 #include <cstdlib>
+#include <cstdint>
 #include <cstring>
 #include <new>
+
 #include <sys/types.h>
 
 

--- a/include/memory/errors.h
+++ b/include/memory/errors.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,9 +23,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_MEMORY_ERRORS_H_
 #define COREVM_MEMORY_ERRORS_H_
 
-#include <string>
-#include <boost/format.hpp>
 #include "../errors.h"
+
+#include <boost/format.hpp>
+
+#include <string>
 
 
 namespace corevm {

--- a/include/memory/object_container.h
+++ b/include/memory/object_container.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,9 +23,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_OBJECT_CONTAINER_H_
 #define COREVM_OBJECT_CONTAINER_H_
 
+#include "errors.h"
+
 #include <iterator>
 #include <set>
-#include "errors.h"
 
 
 namespace corevm {

--- a/include/memory/sequential_allocation_scheme.h
+++ b/include/memory/sequential_allocation_scheme.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,8 +23,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_SEQUENTIAL_ALLOCATION_SCHEME_H_
 #define COREVM_SEQUENTIAL_ALLOCATION_SCHEME_H_
 
-#include <list>
 #include "allocation_scheme.h"
+
+#include <cstdint>
+#include <list>
 
 
 namespace corevm {

--- a/include/runtime/errors.h
+++ b/include/runtime/errors.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,9 +23,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef RUNTIME_ERRORS_H_
 #define RUNTIME_ERRORS_H_
 
-#include <string>
-#include <boost/format.hpp>
 #include "../errors.h"
+
+#include <boost/format.hpp>
+
+#include <string>
 
 
 namespace corevm {

--- a/include/runtime/frame.h
+++ b/include/runtime/frame.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,12 +23,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_FRAME_H_
 #define COREVM_FRAME_H_
 
-#include <list>
-#include <stack>
 #include "common.h"
 #include "errors.h"
 #include "../../include/dyobj/dyobj_id.h"
 #include "../../include/types/native_type_handle.h"
+
+#include <list>
+#include <stack>
 
 
 namespace corevm {

--- a/include/runtime/gc_rule.h
+++ b/include/runtime/gc_rule.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,8 +23,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_GC_RULE_H_
 #define COREVM_GC_RULE_H_
 
-#include <unordered_map>
 #include "common.h"
+
+#include <unordered_map>
 
 
 namespace corevm {

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,10 +23,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_INSTRUCTION_H_
 #define COREVM_INSTRUCTION_H_
 
-#include <string>
-#include <unordered_map>
 #include "common.h"
 #include "errors.h"
+
+#include <string>
+#include <unordered_map>
 
 
 namespace corevm {

--- a/include/runtime/instr_block.h
+++ b/include/runtime/instr_block.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,8 +23,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_INSTR_BLOCK_H_
 #define COREVM_INSTR_BLOCK_H_
 
-#include <vector>
 #include "instr.h"
+
+#include <vector>
 
 
 namespace corevm {

--- a/include/runtime/native_types_pool.h
+++ b/include/runtime/native_types_pool.h
@@ -23,17 +23,19 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_NATIVE_TYPES_POOL_H_
 #define COREVM_NATIVE_TYPES_POOL_H_
 
-#include <string> // TODO: [COREVM-90] Remove extraneous header in native_types_pool.h
-#include <limits> // TODO: [COREVM-90] Remove extraneous header in native_types_pool.h
-#include <sneaker/allocator/allocator.h>
+#include "common.h"
+#include "errors.h"
 #include "../dyobj/common.h"
 #include "../memory/allocator.h"
 #include "../memory/alloc_policy.h"
 #include "../memory/object_container.h"
 #include "../memory/sequential_allocation_scheme.h"
 #include "../types/native_type_handle.h"
-#include "common.h"
-#include "errors.h"
+
+#include <sneaker/allocator/allocator.h>
+
+#include <string>
+#include <limits>
 
 
 namespace corevm {

--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,10 +23,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_PROCESS_H_
 #define COREVM_PROCESS_H_
 
-#include <climits>
-#include <stack>
-#include <unordered_map>
-#include <sneaker/threading/fixed_time_interval_daemon_service.h>
 #include "errors.h"
 #include "frame.h"
 #include "instr.h"
@@ -37,6 +33,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../../include/dyobj/dynamic_object_heap.h"
 #include "../../include/gc/garbage_collector.h"
 #include "../../include/gc/garbage_collection_scheme.h"
+
+#include <sneaker/threading/fixed_time_interval_daemon_service.h>
+
+#include <climits>
+#include <stack>
+#include <unordered_map>
 
 
 namespace corevm {

--- a/include/runtime/sighandler.h
+++ b/include/runtime/sighandler.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -22,6 +22,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #ifndef COREVM_SIGHANDLER_H_
 #define COREVM_SIGHANDLER_H_
+
+#include <signal.h>
 
 
 namespace corevm {

--- a/include/runtime/sighandler_registrar.h
+++ b/include/runtime/sighandler_registrar.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -23,11 +23,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_SIGHANDLER_REGISTRAR_H_
 #define COREVM_SIGHANDLER_REGISTRAR_H_
 
-#include <csignal>
-#include <setjmp.h>
-#include <unordered_map>
 #include "process.h"
 #include "sighandler.h"
+
+#include <csignal>
+#include <unordered_map>
+
+#include <setjmp.h>
 
 
 namespace corevm {

--- a/src/dyobj/dyobj_id_helper.cc
+++ b/src/dyobj/dyobj_id_helper.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,10 +20,14 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <stdexcept>
-#include <boost/lexical_cast.hpp>
+
 #include "../../include/dyobj/dyobj_id_helper.h"
+
 #include "../../include/dyobj/errors.h"
+
+#include <stdexcept>
+
+#include <boost/lexical_cast.hpp>
 
 
 sneaker::atomic::atomic_incrementor<

--- a/src/frontend/loader.cc
+++ b/src/frontend/loader.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,17 +20,20 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
+#include "../../include/frontend/loader.h"
+
+#include "../../include/frontend/errors.h"
+#include "../../include/frontend/schema_repository.h"
+
+#include <boost/format.hpp>
+#include <sneaker/json/json.h>
+#include <sneaker/json/json_schema.h>
+
 #include <fstream>
 #include <ios>
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <boost/format.hpp>
-#include <sneaker/json/json.h>
-#include <sneaker/json/json_schema.h>
-#include "../../include/frontend/errors.h"
-#include "../../include/frontend/loader.h"
-#include "../../include/frontend/schema_repository.h"
 
 
 using boost::format;

--- a/src/frontend/schema_repository.cc
+++ b/src/frontend/schema_repository.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,11 +20,12 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
+#include "../../include/frontend/schema_repository.h"
+
 #include <algorithm>
 #include <iterator>
 #include <string>
 #include <unordered_map>
-#include "../../include/frontend/schema_repository.h"
 
 
 const std::unordered_map<std::string, std::string>

--- a/src/gc/mark_and_sweep_garbage_collection_scheme.cc
+++ b/src/gc/mark_and_sweep_garbage_collection_scheme.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,8 +20,9 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <algorithm>
 #include "../../include/gc/garbage_collection_scheme.h"
+
+#include <algorithm>
 
 
 void

--- a/src/gc/reference_count_garbage_collection_scheme.cc
+++ b/src/gc/reference_count_garbage_collection_scheme.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,11 +20,13 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
+#include "../../include/gc/garbage_collection_scheme.h"
+
+#include <sneaker/algorithm/tarjan.h>
+
 #include <algorithm>
 #include <set>
 #include <unordered_map>
-#include <sneaker/algorithm/tarjan.h>
-#include "../../include/gc/garbage_collection_scheme.h"
 
 
 void

--- a/src/memory/sequential_allocation_scheme.cc
+++ b/src/memory/sequential_allocation_scheme.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,12 +20,14 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
+#include "../../include/memory/sequential_allocation_scheme.h"
+
+#include <sneaker/libc/math.h>
+
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
 #include <string>
-#include <sneaker/libc/math.h>
-#include "../../include/memory/sequential_allocation_scheme.h"
 
 
 typedef corevm::memory::sequential_allocation_scheme::iterator iterator_type;

--- a/src/runtime/gc_rule.cc
+++ b/src/runtime/gc_rule.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,8 +20,9 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include "../../include/runtime/process.h"
 #include "../../include/runtime/gc_rule.h"
+
+#include "../../include/runtime/process.h"
 
 
 const double corevm::runtime::gc_rule_by_heap_size::DEFAULT_CUTOFF = 0.75f;

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,13 +20,16 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
+#include "../../include/runtime/instr.h"
+
+#include "../../include/runtime/process.h"
+#include "../../include/types/interfaces.h"
+
+#include <boost/format.hpp>
+
 #include <csignal>
 #include <cstdlib>
 #include <stdexcept>
-#include <boost/format.hpp>
-#include "../../include/runtime/instr.h"
-#include "../../include/runtime/process.h"
-#include "../../include/types/interfaces.h"
 
 
 const corevm::runtime::instr_handler_meta::map_type

--- a/src/runtime/native_types_pool.cc
+++ b/src/runtime/native_types_pool.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -22,6 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 
 #include "../../include/runtime/native_types_pool.h"
+
 #include "../../include/runtime/utils.h"
 
 

--- a/src/runtime/sighandler.cc
+++ b/src/runtime/sighandler.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,8 +20,10 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include "../../include/runtime/process.h"
 #include "../../include/runtime/sighandler.h"
+
+#include "../../include/runtime/process.h"
+
 
 void
 corevm::runtime::sighandler_SIGFPE::handle_signal(

--- a/src/runtime/sighandler_registrar.cc
+++ b/src/runtime/sighandler_registrar.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -21,6 +21,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #include "../../include/runtime/sighandler_registrar.h"
+
 #include "../../include/runtime/sighandler.h"
 
 

--- a/tests/dyobj/dynamic_object_heap_unittest.cc
+++ b/tests/dyobj/dynamic_object_heap_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,11 +20,12 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <sneaker/testing/_unittest.h>
 #include "../../include/dyobj/dynamic_object.h"
 #include "../../include/dyobj/dynamic_object_heap.h"
 #include "../../include/gc/garbage_collector.h"
 #include "../../include/gc/garbage_collection_scheme.h"
+
+#include <sneaker/testing/_unittest.h>
 
 
 class dummy_dynamic_object_manager {};

--- a/tests/dyobj/dynamic_object_unittest.cc
+++ b/tests/dyobj/dynamic_object_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,10 +20,12 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <map>
-#include <sneaker/testing/_unittest.h>
 #include "../../include/dyobj/dynamic_object.h"
 #include "../../include/dyobj/flags.h"
+
+#include <sneaker/testing/_unittest.h>
+
+#include <map>
 
 
 class dummy_dynamic_object_manager {};

--- a/tests/dyobj/heap_allocator_unittest.cc
+++ b/tests/dyobj/heap_allocator_unittest.cc
@@ -20,9 +20,10 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <sneaker/testing/_unittest.h>
-#include "../../include/memory/sequential_allocation_scheme.h"
 #include "../../include/dyobj/heap_allocator.h"
+#include "../../include/memory/sequential_allocation_scheme.h"
+
+#include <sneaker/testing/_unittest.h>
 
 
 class heap_allocator_unit_test : public ::testing::Test {

--- a/tests/frontend/loader_unittest.cc
+++ b/tests/frontend/loader_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,11 +20,13 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
+#include "../../include/frontend/loader.h"
+
+#include <sneaker/testing/_unittest.h>
+
 #include <cassert>
 #include <fstream>
 #include <string>
-#include <sneaker/testing/_unittest.h>
-#include "../../include/frontend/loader.h"
 
 
 class loader_unittest : public ::testing::Test {

--- a/tests/frontend/schema_repository_unittest.cc
+++ b/tests/frontend/schema_repository_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,9 +20,12 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <cassert>
-#include <sneaker/testing/_unittest.h>
 #include "../../include/frontend/schema_repository.h"
+
+#include <sneaker/testing/_unittest.h>
+
+#include <cassert>
+
 
 using corevm::frontend::schema_repository;
 

--- a/tests/gc/garbage_collection_unittest.cc
+++ b/tests/gc/garbage_collection_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,11 +20,12 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <sneaker/testing/_unittest.h>
 #include "../../include/dyobj/dynamic_object.h"
 #include "../../include/dyobj/dynamic_object_heap.h"
 #include "../../include/gc/garbage_collector.h"
 #include "../../include/gc/garbage_collection_scheme.h"
+
+#include <sneaker/testing/_unittest.h>
 
 
 template<class GarbageCollectionScheme>

--- a/tests/memory/alloc_policy_unittest.cc
+++ b/tests/memory/alloc_policy_unittest.cc
@@ -20,10 +20,12 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <climits>
-#include <sneaker/testing/_unittest.h>
 #include "../../include/memory/alloc_policy.h"
 #include "../../include/memory/sequential_allocation_scheme.h"
+
+#include <sneaker/testing/_unittest.h>
+
+#include <climits>
 
 
 class alloc_policy_unit_test : public ::testing::Test {

--- a/tests/memory/allocator_unittest.cc
+++ b/tests/memory/allocator_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,10 +20,12 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <cassert>
-#include <sneaker/testing/_unittest.h>
 #include "../../include/memory/allocator.h"
 #include "../../include/memory/sequential_allocation_scheme.h"
+
+#include <sneaker/testing/_unittest.h>
+
+#include <cassert>
 
 
 const int HEAP_STORAGE_FOR_TEST = 1024;

--- a/tests/memory/object_container_unittest.cc
+++ b/tests/memory/object_container_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,11 +20,13 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <algorithm>
-#include <set>
-#include <sneaker/testing/_unittest.h>
 #include "../../include/memory/errors.h"
 #include "../../include/memory/object_container.h"
+
+#include <sneaker/testing/_unittest.h>
+
+#include <algorithm>
+#include <set>
 
 
 class object_container_unittest : public ::testing::Test {

--- a/tests/runtime/frame_unittest.cc
+++ b/tests/runtime/frame_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,10 +20,11 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <sneaker/testing/_unittest.h>
 #include "../../include/dyobj/dyobj_id_helper.h"
 #include "../../include/runtime/frame.h"
 #include "../../include/types/native_type_handle.h"
+
+#include <sneaker/testing/_unittest.h>
 
 
 class frame_unittest : public ::testing::Test {};

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,14 +20,16 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <algorithm>
-#include <climits>
-#include <list>
-#include <sneaker/testing/_unittest.h>
 #include "../../include/runtime/process.h"
 #include "../../include/types/interfaces.h"
 #include "../../include/types/native_type_handle.h"
 #include "../../include/types/types.h"
+
+#include <sneaker/testing/_unittest.h>
+
+#include <algorithm>
+#include <climits>
+#include <list>
 
 
 using corevm::runtime::process;

--- a/tests/runtime/native_types_pool_unittest.cc
+++ b/tests/runtime/native_types_pool_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,9 +20,10 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <sneaker/testing/_unittest.h>
 #include "../../include/runtime/native_types_pool.h"
 #include "../../include/types/native_type_handle.h"
+
+#include <sneaker/testing/_unittest.h>
 
 
 class native_types_pool_unittest : public ::testing::Test {};

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,11 +20,12 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <sneaker/testing/_unittest.h>
 #include "../../include/dyobj/dyobj_id_helper.h"
 #include "../../include/runtime/gc_rule.h"
 #include "../../include/runtime/process.h"
 #include "../../include/runtime/sighandler_registrar.h"
+
+#include <sneaker/testing/_unittest.h>
 
 
 class process_unittest : public ::testing::Test {};

--- a/tests/runtime/sighandler_registrar_unittest.cc
+++ b/tests/runtime/sighandler_registrar_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,9 +20,10 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <sneaker/testing/_unittest.h>
 #include "../../include/runtime/process.h"
 #include "../../include/runtime/sighandler_registrar.h"
+
+#include <sneaker/testing/_unittest.h>
 
 
 class sighandler_registrar_test : public ::testing::Test {};

--- a/tests/types/native_array_type_interfaces_test.cc
+++ b/tests/types/native_array_type_interfaces_test.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,8 +20,9 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <string>
 #include "native_type_interfaces_test_base.h"
+
+#include <string>
 
 
 class native_array_type_interfaces_test : public native_type_interfaces_test_base {};

--- a/tests/types/native_array_unittest.cc
+++ b/tests/types/native_array_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,11 +20,13 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <stdexcept>
-#include <sneaker/testing/_unittest.h>
 #include "../../include/types/errors.h"
 #include "../../include/types/native_array.h"
 #include "../../include/types/types.h"
+
+#include <sneaker/testing/_unittest.h>
+
+#include <stdexcept>
 
 
 class native_array_unittest : public ::testing::Test {

--- a/tests/types/native_map_type_interfaces_test.cc
+++ b/tests/types/native_map_type_interfaces_test.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,8 +20,9 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <string>
 #include "native_type_interfaces_test_base.h"
+
+#include <string>
 
 
 class native_map_type_interfaces_test : public native_type_interfaces_test_base {};

--- a/tests/types/native_map_unittest.cc
+++ b/tests/types/native_map_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,10 +20,12 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <stdexcept>
-#include <sneaker/testing/_unittest.h>
 #include "../../include/types/errors.h"
 #include "../../include/types/native_map.h"
+
+#include <sneaker/testing/_unittest.h>
+
+#include <stdexcept>
 
 
 class native_map_unittest : public ::testing::Test {};

--- a/tests/types/native_string_type_interfaces_test.cc
+++ b/tests/types/native_string_type_interfaces_test.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,8 +20,9 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <string>
 #include "native_type_interfaces_test_base.h"
+
+#include <string>
 
 
 class native_string_type_interfaces_test : public native_type_interfaces_test_base {

--- a/tests/types/native_string_unittest.cc
+++ b/tests/types/native_string_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,9 +20,10 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <sneaker/testing/_unittest.h>
 #include "../../include/types/errors.h"
 #include "../../include/types/native_string.h"
+
+#include <sneaker/testing/_unittest.h>
 
 
 class native_string_unittest : public ::testing::Test {};

--- a/tests/types/native_type_handle_unittest.cc
+++ b/tests/types/native_type_handle_unittest.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,8 +20,9 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <sneaker/testing/_unittest.h>
 #include "../../include/types/native_type_handle.h"
+
+#include <sneaker/testing/_unittest.h>
 
 
 class native_type_handle_unittest : public ::testing::Test {

--- a/tests/types/native_type_interfaces_test_base.h
+++ b/tests/types/native_type_interfaces_test_base.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,8 +20,9 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include <sneaker/testing/_unittest.h>
 #include "../../include/types/interfaces.h"
+
+#include <sneaker/testing/_unittest.h>
 
 
 class native_type_interfaces_test_base : public ::testing::Test {


### PR DESCRIPTION
Currently the practice for include orders that we employ is to have system and library headers come before custom headers. This, however, is bad in a sense that having system/library headers come first can hide missing headers that are in our custom headers. The practice that the industry uses is as follows:

* corresponding header file
* necessary project headers
* 3rd party libraries headers
* standard libraries headers
* system headers

And let's add a blank line between each section.