### PR TITLE
[COREVM-101] Load instruction vectors into process in signal vector loader

### DIFF
--- a/include/runtime/sighandler_registrar.h
+++ b/include/runtime/sighandler_registrar.h
@@ -27,6 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "sighandler.h"
 
 #include <csignal>
+#include <string>
 #include <unordered_map>
 
 #include <setjmp.h>
@@ -58,9 +59,12 @@ public:
 
   static bool sig_raised;
 
+  static sig_atomic_t get_sig_value_from_string(const std::string&);
+
 protected:
   static corevm::runtime::process* process;
   static const std::unordered_map<sig_atomic_t, sighandler_wrapper> handler_map;
+  static const std::unordered_map<std::string, sig_atomic_t> sig_value_to_str_map;
 };
 
 

--- a/src/runtime/sighandler_registrar.cc
+++ b/src/runtime/sighandler_registrar.cc
@@ -24,6 +24,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "../../include/runtime/sighandler.h"
 
+#include <string>
+
 
 corevm::runtime::process* corevm::runtime::sighandler_registrar::process = nullptr;
 
@@ -76,6 +78,16 @@ const std::unordered_map<sig_atomic_t, corevm::runtime::sighandler_wrapper> \
 };
 
 
+const std::unordered_map<std::string, sig_atomic_t> \
+  corevm::runtime::sighandler_registrar::sig_value_to_str_map
+{
+
+  //-----------------  Arithmetic and execution signals -----------------------/
+
+  { "SIGFPE", SIGFPE },
+};
+
+
 void
 corevm::runtime::sighandler_registrar::init(corevm::runtime::process* process)
 {
@@ -114,4 +126,10 @@ corevm::runtime::sighandler_registrar::handle_signal(int signum)
   corevm::runtime::sighandler_registrar::sig_raised = true;
 
   siglongjmp(corevm::runtime::sighandler_registrar::get_sigjmp_env(), 1);
+}
+
+sig_atomic_t
+corevm::runtime::sighandler_registrar::get_sig_value_from_string(const std::string& str)
+{
+  return sig_value_to_str_map.at(str);
 }

--- a/src/runtime/sighandler_registrar.cc
+++ b/src/runtime/sighandler_registrar.cc
@@ -84,7 +84,34 @@ const std::unordered_map<std::string, sig_atomic_t> \
 
   //-----------------  Arithmetic and execution signals -----------------------/
 
-  { "SIGFPE", SIGFPE },
+  { "SIGFPE", SIGFPE        },
+  { "SIGKILL", SIGKILL      },
+  { "SIGSEGV", SIGSEGV      },
+  { "SIGBUS", SIGBUS        },
+
+  //---------------------- Termination signals --------------------------------/
+
+  { "SIGABRT",    SIGABRT   },
+  { "SIGINT",     SIGINT    },
+  { "SIGTERM",    SIGTERM   },
+  { "SIGQUIT",    SIGQUIT   },
+
+  //------------------------ Alarm signals ------------------------------------/
+
+  { "SIGALRM",    SIGALRM   },
+  { "SIGVTALRM",  SIGVTALRM },
+  { "SIGPROF",    SIGPROF   },
+
+  //---------------------- Operation error signals ----------------------------/
+
+  { "SIGPIPE",    SIGPIPE   },
+  { "SIGXCPU",    SIGXCPU   },
+  { "SIGXFSZ",    SIGXFSZ   },
+
+  //-------------------- Asynchronous I/O signals -----------------------------/
+
+  { "SIGIO",      SIGIO     },
+  { "SIGURG",     SIGURG    },
 };
 
 

--- a/src/runtime/sighandler_registrar.cc
+++ b/src/runtime/sighandler_registrar.cc
@@ -84,10 +84,10 @@ const std::unordered_map<std::string, sig_atomic_t> \
 
   //-----------------  Arithmetic and execution signals -----------------------/
 
-  { "SIGFPE", SIGFPE        },
-  { "SIGKILL", SIGKILL      },
-  { "SIGSEGV", SIGSEGV      },
-  { "SIGBUS", SIGBUS        },
+  { "SIGFPE",     SIGFPE    },
+  { "SIGKILL",    SIGKILL   },
+  { "SIGSEGV",    SIGSEGV   },
+  { "SIGBUS",     SIGBUS    },
 
   //---------------------- Termination signals --------------------------------/
 


### PR DESCRIPTION
In #33 {{signal_vector_loader}} was added, which can read signal vectors from files and load them into processes. However, there is currently no way to read signal vectors in JSON format, so this was blocked until #34 was done.