### PR TITLE
[COREVM-106] Relocate `get_vector_from_json` definiton

### DIFF
--- a/include/frontend/bytecode_runner.h
+++ b/include/frontend/bytecode_runner.h
@@ -37,10 +37,7 @@ namespace frontend {
 using sneaker::json::JSON;
 
 
-class bytecode_runner {
-public:
-  corevm::runtime::instr_block get_vector_from_json(const JSON&);
-};
+class bytecode_runner {};
 
 
 } /* end namespace frontend */

--- a/include/frontend/utils.h
+++ b/include/frontend/utils.h
@@ -20,9 +20,30 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include "../../include/frontend/bytecode_runner.h"
+#ifndef COREVM_FRONTEND_UTILS_H_
+#define COREVM_FRONTEND_UTILS_H_
 
-#include "../../include/runtime/instr_block.h"
-#include "../../include/runtime/instr.h"
+#include "../runtime/instr_block.h"
 
 #include <sneaker/json/json.h>
+
+
+namespace corevm {
+
+
+namespace frontend {
+
+
+using sneaker::json::JSON;
+
+
+corevm::runtime::instr_block get_vector_from_json(const JSON&);
+
+
+}; /* end namespace frontend */
+
+
+}; /* end namespace corevm */
+
+
+#endif /* COREVM_FRONTEND_UTILS_H_ */

--- a/src/frontend/signal_vector_loader.cc
+++ b/src/frontend/signal_vector_loader.cc
@@ -22,8 +22,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #include "../../include/frontend/signal_vector_loader.h"
 
-#include "../../include/frontend/bytecode_runner.h"
 #include "../../include/frontend/errors.h"
+#include "../../include/frontend/utils.h"
 #include "../../include/runtime/process.h"
 #include "../../include/runtime/sighandler_registrar.h"
 
@@ -200,8 +200,7 @@ corevm::frontend::signal_vector_loader::load(corevm::runtime::process& process) 
     std::string signal_str = static_cast<std::string>(itr->first);
     const JSON& signal_json = static_cast<const JSON>(itr->second);
 
-    corevm::frontend::bytecode_runner runner;
-    corevm::runtime::instr_block vector = runner.get_vector_from_json(signal_json);
+    corevm::runtime::instr_block vector = corevm::frontend::get_vector_from_json(signal_json);
 
     sig_atomic_t sig = corevm::runtime::sighandler_registrar::get_sig_value_from_string(signal_str);
 

--- a/src/frontend/utils.cc
+++ b/src/frontend/utils.cc
@@ -20,9 +20,52 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include "../../include/frontend/bytecode_runner.h"
-
+#include "../../include/frontend/utils.h"
 #include "../../include/runtime/instr_block.h"
 #include "../../include/runtime/instr.h"
 
 #include <sneaker/json/json.h>
+
+#include <cassert>
+
+
+corevm::runtime::instr_block
+corevm::frontend::get_vector_from_json(const JSON& json)
+{
+  assert(json.type() == JSON::ARRAY);
+
+  const JSON::array& vector = json.array_items();
+  corevm::runtime::instr_block::block_type block;
+
+  for (auto itr = vector.begin(); itr != vector.end(); ++itr) {
+    const JSON& instr_json = *itr;
+    const JSON::array& instr_tuple = instr_json.array_items();
+
+    corevm::runtime::instr_code code = 0;
+    corevm::runtime::instr_oprd oprd1 = 0;
+    corevm::runtime::instr_oprd oprd2 = 0;
+
+    const JSON& code_raw = instr_tuple[0];
+    code = static_cast<corevm::runtime::instr_code>(code_raw.int_value());
+
+    if (instr_tuple.size() >= 2) {
+      const JSON& oprd1_raw = instr_tuple[1];
+      oprd1 = static_cast<corevm::runtime::instr_oprd>(oprd1_raw.int_value());
+    }
+
+    if (instr_tuple.size() == 3) {
+      const JSON& oprd2_raw = instr_tuple[2];
+      oprd2 = static_cast<corevm::runtime::instr_oprd>(oprd2_raw.int_value());
+    }
+
+    block.push_back(corevm::runtime::instr
+      {
+        .code = code,
+        .oprd1 = oprd1,
+        .oprd2 = oprd2,
+      }
+    );
+  }
+
+  return corevm::runtime::instr_block(block);
+}

--- a/src/frontend/utils.cc
+++ b/src/frontend/utils.cc
@@ -21,6 +21,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #include "../../include/frontend/utils.h"
+
 #include "../../include/runtime/instr_block.h"
 #include "../../include/runtime/instr.h"
 

--- a/tests/frontend/bytecode_runner_unittest.cc
+++ b/tests/frontend/bytecode_runner_unittest.cc
@@ -36,37 +36,3 @@ using sneaker::json::JSON;
 
 
 class bytecode_runner_unittest : public ::testing::Test {};
-
-
-
-TEST_F(bytecode_runner_unittest, TestGetVectorFromJson)
-{
-    std::string vector_str = "["
-      "[10, 11, 12],"
-      "[1],"
-      "[22, 33]"
-    "]";
-
-    const JSON vector_json = sneaker::json::parse(vector_str);
-
-    corevm::frontend::bytecode_runner runner;
-    corevm::runtime::instr_block vector = runner.get_vector_from_json(vector_json);
-
-    corevm::runtime::instr_block::block_type block = vector.block();
-
-    corevm::runtime::instr instr1 = block[0];
-    corevm::runtime::instr instr2 = block[1];
-    corevm::runtime::instr instr3 = block[2];
-
-    ASSERT_EQ(10, instr1.code);
-    ASSERT_EQ(11, instr1.oprd1);
-    ASSERT_EQ(12, instr1.oprd2);
-
-    ASSERT_EQ(1, instr2.code);
-    ASSERT_EQ(0, instr2.oprd1);
-    ASSERT_EQ(0, instr2.oprd2);
-
-    ASSERT_EQ(22, instr3.code);
-    ASSERT_EQ(33, instr3.oprd1);
-    ASSERT_EQ(0, instr3.oprd2);
-}

--- a/tests/frontend/utils_unittest.cc
+++ b/tests/frontend/utils_unittest.cc
@@ -20,9 +20,50 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include "../../include/frontend/bytecode_runner.h"
-
+#include "../../include/frontend/utils.h"
 #include "../../include/runtime/instr_block.h"
 #include "../../include/runtime/instr.h"
 
+#include <sneaker/testing/_unittest.h>
+#include <sneaker/json/json_parser.h>
 #include <sneaker/json/json.h>
+
+#include <string>
+
+
+using sneaker::json::JSON;
+
+
+class utils_unittest : public ::testing::Test {};
+
+
+TEST_F(utils_unittest, TestGetVectorFromJson)
+{
+  std::string vector_str = "["
+    "[10, 11, 12],"
+    "[1],"
+    "[22, 33]"
+  "]";
+
+  const JSON vector_json = sneaker::json::parse(vector_str);
+
+  corevm::runtime::instr_block vector = corevm::frontend::get_vector_from_json(vector_json);
+
+  corevm::runtime::instr_block::block_type block = vector.block();
+
+  corevm::runtime::instr instr1 = block[0];
+  corevm::runtime::instr instr2 = block[1];
+  corevm::runtime::instr instr3 = block[2];
+
+  ASSERT_EQ(10, instr1.code);
+  ASSERT_EQ(11, instr1.oprd1);
+  ASSERT_EQ(12, instr1.oprd2);
+
+  ASSERT_EQ(1, instr2.code);
+  ASSERT_EQ(0, instr2.oprd1);
+  ASSERT_EQ(0, instr2.oprd2);
+
+  ASSERT_EQ(22, instr3.code);
+  ASSERT_EQ(33, instr3.oprd1);
+  ASSERT_EQ(0, instr3.oprd2);
+}


### PR DESCRIPTION
In #34, `get_vector_from_json` should not be a member of `corevm::frontend::bytecode_runner`. It makes sense to move it out of the class, and perhaps put it under `include/frontend/utils.h`. 