### PR TITLE
[COREVM-110] Redefine vector type

### DIFF
--- a/include/frontend/utils.h
+++ b/include/frontend/utils.h
@@ -23,7 +23,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_FRONTEND_UTILS_H_
 #define COREVM_FRONTEND_UTILS_H_
 
-#include "../runtime/instr_block.h"
+#include "../runtime/vector.h"
 
 #include <sneaker/json/json.h>
 
@@ -37,7 +37,7 @@ namespace frontend {
 using sneaker::json::JSON;
 
 
-corevm::runtime::instr_block get_vector_from_json(const JSON&);
+corevm::runtime::vector get_vector_from_json(const JSON&);
 
 
 }; /* end namespace frontend */

--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -170,7 +170,7 @@ private:
   uint8_t m_gc_flag;
   corevm::runtime::instr_addr m_pc;
   std::vector<corevm::runtime::instr> m_instrs;
-  std::vector<corevm::runtime::vector> m_vector;
+  std::vector<corevm::runtime::vector> m_vectors;
   corevm::dyobj::dynamic_object_heap<garbage_collection_scheme::dynamic_object_manager> m_dynamic_object_heap;
   std::stack<corevm::dyobj::dyobj_id> m_dyobj_stack;
   std::stack<corevm::runtime::frame> m_call_stack;

--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -26,9 +26,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "errors.h"
 #include "frame.h"
 #include "instr.h"
-#include "instr_block.h"
 #include "native_types_pool.h"
 #include "sighandler.h"
+#include "vector.h"
 #include "../../include/dyobj/common.h"
 #include "../../include/dyobj/dynamic_object_heap.h"
 #include "../../include/gc/garbage_collector.h"
@@ -131,7 +131,7 @@ public:
 
   void append_instrs(const std::vector<corevm::runtime::instr>&);
 
-  void append_instr_block(const corevm::runtime::instr_block&);
+  void append_vector(const corevm::runtime::vector&);
 
   virtual bool start();
 
@@ -147,7 +147,7 @@ public:
 
   void set_encoding_key_value_pair(uint64_t, const std::string&);
 
-  void set_sig_instr_block(sig_atomic_t, corevm::runtime::instr_block&);
+  void set_sig_vector(sig_atomic_t, corevm::runtime::vector&);
 
   void handle_signal(sig_atomic_t, corevm::runtime::sighandler*);
 
@@ -164,20 +164,20 @@ private:
 
   bool should_gc();
 
-  void insert_instr_block(corevm::runtime::instr_block& block);
+  void insert_vector(corevm::runtime::vector& vector);
 
   bool m_pause_exec;
   uint8_t m_gc_flag;
   corevm::runtime::instr_addr m_pc;
   std::vector<corevm::runtime::instr> m_instrs;
-  std::vector<corevm::runtime::instr_block> m_instr_blocks;
+  std::vector<corevm::runtime::vector> m_vector;
   corevm::dyobj::dynamic_object_heap<garbage_collection_scheme::dynamic_object_manager> m_dynamic_object_heap;
   std::stack<corevm::dyobj::dyobj_id> m_dyobj_stack;
   std::stack<corevm::runtime::frame> m_call_stack;
   native_types_pool_type m_ntvhndl_pool;
   corevm::runtime::instr_handler_meta m_instr_handler_meta;
   std::unordered_map<uint64_t, std::string> m_encoding_map;
-  std::unordered_map<sig_atomic_t, corevm::runtime::instr_block> m_sig_instr_map;
+  std::unordered_map<sig_atomic_t, corevm::runtime::vector> m_sig_instr_map;
 };
 
 

--- a/include/runtime/vector.h
+++ b/include/runtime/vector.h
@@ -20,8 +20,8 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#ifndef COREVM_INSTR_BLOCK_H_
-#define COREVM_INSTR_BLOCK_H_
+#ifndef COREVM_VECTOR_H_
+#define COREVM_VECTOR_H_
 
 #include "instr.h"
 
@@ -34,46 +34,13 @@ namespace corevm {
 namespace runtime {
 
 
-class instr_block {
-public:
-  using block_type = typename std::vector<corevm::runtime::instr>;
-
-  explicit instr_block(block_type& instrs):
-    m_block(instrs)
-  {
-  }
-
-  explicit instr_block(std::initializer_list<corevm::runtime::instr> instrs):
-    m_block(instrs)
-  {
-  }
-
-  instr_block& operator=(const instr_block& other) {
-    m_block = other.block();
-    return *this;
-  }
-
-  block_type block() const {
-    return m_block;
-  }
-
-  block_type::iterator begin() {
-    return m_block.begin();
-  }
-
-  block_type::iterator end() {
-    return m_block.end();
-  }
-
-private:
-  block_type m_block;
-};
+typedef std::vector<corevm::runtime::instr> vector;
 
 
-} /* end namespace runtime */
+}; /* end namespace runtime */
 
 
-} /* end namespace corevm */
+}; /* end namespace corevm */
 
 
-#endif /* COREVM_INSTR_BLOCK_H_ */
+#endif /* COREVM_VECTOR_H_ */

--- a/src/frontend/bytecode_loader.cc
+++ b/src/frontend/bytecode_loader.cc
@@ -24,8 +24,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "../../include/frontend/errors.h"
 #include "../../include/frontend/utils.h"
-#include "../../include/runtime/instr_block.h"
 #include "../../include/runtime/process.h"
+#include "../../include/runtime/vector.h"
 
 #include <boost/format.hpp>
 #include <sneaker/json/json.h>
@@ -220,9 +220,9 @@ public:
       const JSON::string& __name__ = vector_object.at("__name__").string_value();
       const JSON& __inner__ = vector_object.at("__inner__");
 
-      corevm::runtime::instr_block block = corevm::frontend::get_vector_from_json(__inner__);
+      corevm::runtime::vector vector = corevm::frontend::get_vector_from_json(__inner__);
 
-      process.append_instr_block(block);
+      process.append_vector(vector);
     }
   }
 };

--- a/src/frontend/signal_vector_loader.cc
+++ b/src/frontend/signal_vector_loader.cc
@@ -26,6 +26,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../../include/frontend/utils.h"
 #include "../../include/runtime/process.h"
 #include "../../include/runtime/sighandler_registrar.h"
+#include "../../include/runtime/vector.h"
 
 #include <boost/format.hpp>
 #include <sneaker/json/json.h>
@@ -200,11 +201,11 @@ corevm::frontend::signal_vector_loader::load(corevm::runtime::process& process) 
     std::string signal_str = static_cast<std::string>(itr->first);
     const JSON& signal_json = static_cast<const JSON>(itr->second);
 
-    corevm::runtime::instr_block vector = corevm::frontend::get_vector_from_json(signal_json);
+    corevm::runtime::vector vector = corevm::frontend::get_vector_from_json(signal_json);
 
     sig_atomic_t sig = corevm::runtime::sighandler_registrar::get_sig_value_from_string(signal_str);
 
-    process.set_sig_instr_block(sig, vector);
+    process.set_sig_vector(sig, vector);
   }
 }
 

--- a/src/frontend/utils.cc
+++ b/src/frontend/utils.cc
@@ -22,23 +22,24 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #include "../../include/frontend/utils.h"
 
-#include "../../include/runtime/instr_block.h"
 #include "../../include/runtime/instr.h"
+#include "../../include/runtime/vector.h"
 
 #include <sneaker/json/json.h>
 
 #include <cassert>
+#include <utility>
 
 
-corevm::runtime::instr_block
+corevm::runtime::vector
 corevm::frontend::get_vector_from_json(const JSON& json)
 {
   assert(json.type() == JSON::ARRAY);
 
-  const JSON::array& vector = json.array_items();
-  corevm::runtime::instr_block::block_type block;
+  const JSON::array& vector_array = json.array_items();
+  corevm::runtime::vector vector;
 
-  for (auto itr = vector.begin(); itr != vector.end(); ++itr) {
+  for (auto itr = vector_array.begin(); itr != vector_array.end(); ++itr) {
     const JSON& instr_json = *itr;
     const JSON::array& instr_tuple = instr_json.array_items();
 
@@ -59,7 +60,7 @@ corevm::frontend::get_vector_from_json(const JSON& json)
       oprd2 = static_cast<corevm::runtime::instr_oprd>(oprd2_raw.int_value());
     }
 
-    block.push_back(corevm::runtime::instr
+    vector.push_back(corevm::runtime::instr
       {
         .code = code,
         .oprd1 = oprd1,
@@ -68,5 +69,5 @@ corevm::frontend::get_vector_from_json(const JSON& json)
     );
   }
 
-  return corevm::runtime::instr_block(block);
+  return std::move(vector);
 }

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -401,9 +401,9 @@ corevm::runtime::process::append_instrs(const std::vector<corevm::runtime::instr
 }
 
 void
-corevm::runtime::process::append_instr_block(const corevm::runtime::instr_block& block)
+corevm::runtime::process::append_vector(const corevm::runtime::vector& vector)
 {
-  m_instr_blocks.push_back(block);
+  m_vector.push_back(vector);
 }
 
 bool
@@ -444,14 +444,14 @@ corevm::runtime::process::set_encoding_key_value_pair(uint64_t key, const std::s
 }
 
 void
-corevm::runtime::process::set_sig_instr_block(
-  sig_atomic_t sig, corevm::runtime::instr_block& block)
+corevm::runtime::process::set_sig_vector(
+  sig_atomic_t sig, corevm::runtime::vector& vector)
 {
-  m_sig_instr_map.insert({sig, block});
+  m_sig_instr_map.insert({sig, vector});
 }
 
 void
-corevm::runtime::process::insert_instr_block(corevm::runtime::instr_block& block)
+corevm::runtime::process::insert_vector(corevm::runtime::vector& block)
 {
   std::vector<corevm::runtime::instr>::iterator pos = m_instrs.begin() + m_pc + 1;
   m_instrs.insert(pos, block.begin(), block.end());
@@ -464,9 +464,9 @@ corevm::runtime::process::handle_signal(
   auto itr = m_sig_instr_map.find(sig);
 
   if(itr != m_sig_instr_map.end()) {
-    corevm::runtime::instr_block block = itr->second;
+    corevm::runtime::vector vector = itr->second;
     this->pause_exec();
-    this->insert_instr_block(block);
+    this->insert_vector(vector);
     this->resume_exec();
 
   } else if(handler != nullptr) {

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -403,7 +403,7 @@ corevm::runtime::process::append_instrs(const std::vector<corevm::runtime::instr
 void
 corevm::runtime::process::append_vector(const corevm::runtime::vector& vector)
 {
-  m_vector.push_back(vector);
+  m_vectors.push_back(vector);
 }
 
 bool

--- a/tests/frontend/utils_unittest.cc
+++ b/tests/frontend/utils_unittest.cc
@@ -21,8 +21,8 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #include "../../include/frontend/utils.h"
-#include "../../include/runtime/instr_block.h"
 #include "../../include/runtime/instr.h"
+#include "../../include/runtime/vector.h"
 
 #include <sneaker/testing/_unittest.h>
 #include <sneaker/json/json_parser.h>
@@ -47,13 +47,11 @@ TEST_F(utils_unittest, TestGetVectorFromJson)
 
   const JSON vector_json = sneaker::json::parse(vector_str);
 
-  corevm::runtime::instr_block vector = corevm::frontend::get_vector_from_json(vector_json);
+  corevm::runtime::vector vector = corevm::frontend::get_vector_from_json(vector_json);
 
-  corevm::runtime::instr_block::block_type block = vector.block();
-
-  corevm::runtime::instr instr1 = block[0];
-  corevm::runtime::instr instr2 = block[1];
-  corevm::runtime::instr instr3 = block[2];
+  corevm::runtime::instr instr1 = vector[0];
+  corevm::runtime::instr instr2 = vector[1];
+  corevm::runtime::instr instr3 = vector[2];
 
   ASSERT_EQ(10, instr1.code);
   ASSERT_EQ(11, instr1.oprd1);

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -24,6 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../../include/runtime/gc_rule.h"
 #include "../../include/runtime/process.h"
 #include "../../include/runtime/sighandler_registrar.h"
+#include "../../include/runtime/vector.h"
 
 #include <sneaker/testing/_unittest.h>
 
@@ -263,10 +264,10 @@ TEST_F(process_signal_handling_unittest, TestHandleSignalWithUserAction)
 
   ASSERT_EQ(0, process.stack_size());
 
-  corevm::runtime::instr_block block_on_signal {
+  corevm::runtime::vector vector {
     { .code=corevm::runtime::instr_enum::NEW, .oprd1=0, .oprd2=0 },
   };
-  process.set_sig_instr_block(sig, block_on_signal);
+  process.set_sig_vector(sig, vector);
 
   process.start();
   raise(sig);
@@ -307,10 +308,10 @@ TEST_F(process_signal_handling_unittest, TestHandleSIGFPE)
 
   process.append_instrs(instrs);
 
-  corevm::runtime::instr_block block_on_signal {
+  corevm::runtime::vector vector {
     { .code=corevm::runtime::instr_enum::NEW, .oprd1=0, .oprd2=0 },
   };
-  process.set_sig_instr_block(sig, block_on_signal);
+  process.set_sig_vector(sig, vector);
 
   process.start();
 


### PR DESCRIPTION
Currently `corevm::runtime::instr_block` is defined as a wrapper class around `std::vector<corevm::runtime::instr>`. This abstraction, however, is unnecessary, and can be simply changed to:

```c++
namespace corevm {


namespace runtime {


typedef std::vector<corevm::runtime::instr> vector


} /* end namespace runtime */


} /* end namespace corevm */
```

The file can also be renamed from `include/runtime/instr_block.h` to `include/runtime/vector.h`.