### PR TITLE
[COREVM-111] Fix include order in process.cc

### DIFF
--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -1,7 +1,7 @@
 /*******************************************************************************
 The MIT License (MIT)
 
-Copyright (c) 2014 Yanzheng Li
+Copyright (c) 2015 Yanzheng Li
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -20,13 +20,15 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
+#include "../../include/runtime/process.h"
+
+#include "../../include/runtime/gc_rule.h"
+#include "../../include/runtime/sighandler_registrar.h"
+
 #include <algorithm>
 #include <cassert>
 #include <setjmp.h>
 #include <stdexcept>
-#include "../../include/runtime/gc_rule.h"
-#include "../../include/runtime/process.h"
-#include "../../include/runtime/sighandler_registrar.h"
 
 
 namespace corevm {


### PR DESCRIPTION
Fix the include order in `src/runtime/process.cc` according to the include order rules defined in the [wiki](https://github.com/yanzhengli/coreVM/wiki/Styles-and-Guidelines#include-directives):
