### PR TITLE
[COREVM-113] Add <cstdint> header for places that use system integer types

### DIFF
--- a/include/gc/garbage_collection_scheme.h
+++ b/include/gc/garbage_collection_scheme.h
@@ -23,10 +23,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_GARBAGE_COLLECTION_SCHEME_H_
 #define COREVM_GARBAGE_COLLECTION_SCHEME_H_
 
-
 #include "../dyobj/dynamic_object.h"
 #include "../dyobj/dynamic_object_heap.h"
 #include "../dyobj/dynamic_object_manager.h"
+
+#include <cstdint>
 
 
 namespace corevm {

--- a/include/memory/allocation_policy.h
+++ b/include/memory/allocation_policy.h
@@ -27,6 +27,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <sneaker/allocator/alloc_policy.h>
 
+#include <cstdint>
+
 
 namespace corevm {
 

--- a/include/memory/errors.h
+++ b/include/memory/errors.h
@@ -27,6 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <boost/format.hpp>
 
+#include <cstdint>
 #include <string>
 
 

--- a/include/memory/object_container.h
+++ b/include/memory/object_container.h
@@ -25,6 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "errors.h"
 
+#include <cstdint>
 #include <iterator>
 #include <set>
 

--- a/include/runtime/common.h
+++ b/include/runtime/common.h
@@ -23,7 +23,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_RUNTIME_COMMON_H_
 #define COREVM_RUNTIME_COMMON_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 
 namespace corevm {

--- a/include/runtime/frame.h
+++ b/include/runtime/frame.h
@@ -28,6 +28,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../../include/dyobj/dyobj_id.h"
 #include "../../include/types/native_type_handle.h"
 
+#include <cstdint>
 #include <list>
 #include <stack>
 

--- a/include/runtime/gc_rule.h
+++ b/include/runtime/gc_rule.h
@@ -25,6 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "common.h"
 
+#include <cstdint>
 #include <unordered_map>
 
 

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -26,6 +26,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "common.h"
 #include "errors.h"
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 

--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -37,6 +37,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <sneaker/threading/fixed_time_interval_daemon_service.h>
 
 #include <climits>
+#include <cstdint>
 #include <stack>
 #include <unordered_map>
 

--- a/include/types/native_array.h
+++ b/include/types/native_array.h
@@ -23,9 +23,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_NATIVE_ARRAY_H_
 #define COREVM_NATIVE_ARRAY_H_
 
+#include "errors.h"
+
+#include <cstdint>
 #include <stdexcept>
 #include <vector>
-#include "errors.h"
 
 
 namespace corevm {

--- a/include/types/native_map.h
+++ b/include/types/native_map.h
@@ -23,9 +23,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_NATIVE_MAP_H_
 #define COREVM_NATIVE_MAP_H_
 
+#include "errors.h"
+
+#include <cstdint>
 #include <stdexcept>
 #include <unordered_map>
-#include "errors.h"
 
 
 namespace corevm {

--- a/include/types/native_string.h
+++ b/include/types/native_string.h
@@ -23,9 +23,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_NATIVE_STRING_H_
 #define COREVM_NATIVE_STRING_H_
 
+#include "errors.h"
+
+#include <cstdint>
 #include <stdexcept>
 #include <string>
-#include "errors.h"
 
 
 namespace corevm {

--- a/include/types/types.h
+++ b/include/types/types.h
@@ -23,10 +23,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_TYPES_H_
 #define COREVM_TYPES_H_
 
-
 #include "native_array.h"
 #include "native_map.h"
 #include "native_string.h"
+
+#include <cstdint>
 
 
 namespace corevm {

--- a/src/memory/sequential_allocation_scheme.cc
+++ b/src/memory/sequential_allocation_scheme.cc
@@ -25,6 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <sneaker/libc/math.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <iomanip>
 #include <iostream>
 #include <string>

--- a/src/runtime/frame.cc
+++ b/src/runtime/frame.cc
@@ -22,6 +22,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #include "../../include/runtime/frame.h"
 
+#include <cstdint>
+
 
 corevm::runtime::frame::frame():
   m_start_addr(corevm::runtime::NONESET_INSTR_ADDR),

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -27,6 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <setjmp.h>
 #include <stdexcept>
 

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -29,6 +29,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <algorithm>
 #include <climits>
+#include <cstdint>
 #include <list>
 
 

--- a/tests/runtime/native_types_pool_unittest.cc
+++ b/tests/runtime/native_types_pool_unittest.cc
@@ -25,6 +25,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <sneaker/testing/_unittest.h>
 
+#include <cstdint>
+
 
 class native_types_pool_unittest : public ::testing::Test {};
 

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -28,6 +28,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <sneaker/testing/_unittest.h>
 
+#include <cstdint>
+
 
 class process_unittest : public ::testing::Test {};
 

--- a/tests/types/native_type_handle_unittest.cc
+++ b/tests/types/native_type_handle_unittest.cc
@@ -24,6 +24,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <sneaker/testing/_unittest.h>
 
+#include <cstdint>
+
 
 class native_type_handle_unittest : public ::testing::Test {
 public:


### PR DESCRIPTION
There are many places in the codebase that make use of system integer types, such as `uint32_t`, `int8_t`, etc. However, not everywhere that uses these types include the header `<cstdint>`. Although everything still compiles, this is wrong and should be fixed.