### PR TITLE
[COREVM-10] Scope implementation and integration

### DIFF
--- a/include/runtime/frame.h
+++ b/include/runtime/frame.h
@@ -39,7 +39,8 @@ namespace corevm {
 namespace runtime {
 
 
-/* Each frame is supposed to have:
+/**
+ * Each frame is supposed to have:
  *
  * - Return address.
  * - Pointer to the address caller frame.
@@ -49,7 +50,7 @@ namespace runtime {
  * - Parameter list (args).
  * - Optional parameter <-> default value mapping (kwargs).
  * - Evaluation stack.
- * */
+ */
 class frame {
 public:
   explicit frame();
@@ -113,7 +114,12 @@ public:
 
   std::list<corevm::dyobj::dyobj_id> get_invisible_objs() const;
 
+  const corevm::runtime::closure_id closure_id() const;
+
+  void set_closure_id(corevm::runtime::closure_id);
+
 protected:
+  corevm::runtime::closure_id m_closure_id;
   corevm::runtime::instr_addr m_start_addr;
   corevm::runtime::instr_addr m_return_addr;
   corevm::runtime::frame* m_parent_scope_frame_ptr;

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -641,7 +641,7 @@ public:
 };
 
 
-class instr_handler_lbobj : public instr_handler {
+class instr_handler_ldobj : public instr_handler {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
 };

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -147,10 +147,6 @@ enum instr_enum : uint32_t {
 
   //------------------------ Function instructions ----------------------------/
 
-  // <frm, _, _>
-  // Creates a new frame and place it on top of the current one.
-  FRAME,
-
   // <putarg, _, _>
   // Pops the top object off the stack and assign it as the next argument
   // for the next call.
@@ -775,12 +771,6 @@ public:
 
 
 //-------------------------- Function instructions ----------------------------/
-
-
-class instr_handler_frm : public instr_handler {
-public:
-  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
-};
 
 
 class instr_handler_putarg : public instr_handler {

--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -41,6 +41,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <climits>
 #include <cstdint>
+#include <list>
 #include <stack>
 #include <unordered_map>
 
@@ -145,6 +146,12 @@ public:
 
   size_t closure_count() const;
 
+  bool has_closure(corevm::runtime::closure_id) const;
+
+  const corevm::runtime::closure& get_closure_by_id(corevm::runtime::closure_id) const;
+
+  void get_frame_by_closure_id(corevm::runtime::closure_id, corevm::runtime::frame**);
+
   virtual bool start();
 
   void maybe_gc();
@@ -185,7 +192,7 @@ private:
   std::vector<corevm::runtime::vector> m_vectors;
   corevm::dyobj::dynamic_object_heap<garbage_collection_scheme::dynamic_object_manager> m_dynamic_object_heap;
   std::stack<corevm::dyobj::dyobj_id> m_dyobj_stack;
-  std::stack<corevm::runtime::frame> m_call_stack;
+  std::list<corevm::runtime::frame> m_call_stack;
   native_types_pool_type m_ntvhndl_pool;
   std::unordered_map<corevm::runtime::closure_id, corevm::runtime::closure> m_closure_table;
   corevm::runtime::instr_handler_meta m_instr_handler_meta;

--- a/src/runtime/frame.cc
+++ b/src/runtime/frame.cc
@@ -22,10 +22,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #include "../../include/runtime/frame.h"
 
+#include "../../include/runtime/common.h"
+#include "../../include/runtime/errors.h"
+
 #include <cstdint>
 
 
 corevm::runtime::frame::frame():
+  m_closure_id(corevm::runtime::NONESET_CLOSURE_ID),
   m_start_addr(corevm::runtime::NONESET_INSTR_ADDR),
   m_return_addr(corevm::runtime::NONESET_INSTR_ADDR),
   m_parent_scope_frame_ptr(nullptr),
@@ -267,4 +271,16 @@ corevm::runtime::frame::get_invisible_objs() const
   }
 
   return ids;
+}
+
+const corevm::runtime::closure_id
+corevm::runtime::frame::closure_id() const
+{
+  return m_closure_id;
+}
+
+void
+corevm::runtime::frame::set_closure_id(corevm::runtime::closure_id closure_id)
+{
+  m_closure_id = closure_id;
 }

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -39,7 +39,7 @@ corevm::runtime::instr_handler_meta::instr_info_map = {
   //--------------------------- Object instructions ---------------------------/
 
   { corevm::runtime::instr_enum::NEW,       { .num_oprd=0, .str="new",       .handler=new corevm::runtime::instr_handler_new()       } },
-  { corevm::runtime::instr_enum::LDOBJ,     { .num_oprd=1, .str="ldobj",     .handler=new corevm::runtime::instr_handler_lbobj()     } },
+  { corevm::runtime::instr_enum::LDOBJ,     { .num_oprd=1, .str="ldobj",     .handler=new corevm::runtime::instr_handler_ldobj()     } },
   { corevm::runtime::instr_enum::STOBJ,     { .num_oprd=1, .str="stobj",     .handler=new corevm::runtime::instr_handler_stobj()     } },
   { corevm::runtime::instr_enum::GETATTR,   { .num_oprd=1, .str="getattr",   .handler=new corevm::runtime::instr_handler_getattr()   } },
   { corevm::runtime::instr_enum::SETATTR,   { .num_oprd=1, .str="setattr",   .handler=new corevm::runtime::instr_handler_setattr()   } },
@@ -356,7 +356,7 @@ corevm::runtime::instr_handler_new::execute(
 }
 
 void
-corevm::runtime::instr_handler_lbobj::execute(
+corevm::runtime::instr_handler_ldobj::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
   corevm::runtime::variable_key key = static_cast<corevm::runtime::variable_key>(instr.oprd1);

--- a/tests/runtime/frame_unittest.cc
+++ b/tests/runtime/frame_unittest.cc
@@ -21,6 +21,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #include "../../include/dyobj/dyobj_id_helper.h"
+#include "../../include/runtime/common.h"
 #include "../../include/runtime/frame.h"
 #include "../../include/types/native_type_handle.h"
 
@@ -211,4 +212,17 @@ TEST_F(frame_unittest, TestListParamValuePairKeys)
   actual_keys.sort();
 
   ASSERT_EQ(expected_keys, actual_keys);
+}
+
+TEST_F(frame_unittest, TestGetAndSetClosureID)
+{
+  corevm::runtime::frame frame;
+
+  ASSERT_EQ(corevm::runtime::NONESET_CLOSURE_ID, frame.closure_id());
+
+  corevm::runtime::closure_id closure_id = 100;
+
+  frame.set_closure_id(closure_id);
+
+  ASSERT_EQ(closure_id, frame.closure_id());
 }

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -102,8 +102,8 @@ TEST_F(process_obj_instrs_test, TestInstrLDOBJ)
 
   parent_frame.set_visible_var(key, id);
 
-  m_process.push_frame(frame);
   m_process.push_frame(parent_frame);
+  m_process.push_frame(frame);
 
   corevm::runtime::instr instr = {
     .code=0,
@@ -258,8 +258,8 @@ TEST_F(process_obj_instrs_test, TestInstrLDOBJ2)
 
   parent_frame.set_invisible_var(key, id);
 
-  m_process.push_frame(frame);
   m_process.push_frame(parent_frame);
+  m_process.push_frame(frame);
 
   corevm::runtime::instr instr = {
     .code=0,

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -20,6 +20,8 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
+#include "../../include/runtime/closure.h"
+#include "../../include/runtime/common.h"
 #include "../../include/runtime/process.h"
 #include "../../include/types/interfaces.h"
 #include "../../include/types/native_type_handle.h"
@@ -69,7 +71,49 @@ TEST_F(process_obj_instrs_test, TestInstrNEW)
 
 TEST_F(process_obj_instrs_test, TestInstrLDOBJ)
 {
-  // TODO: [COREVM-49] Complete instruction set and implementations
+  corevm::runtime::frame frame;
+  corevm::runtime::frame parent_frame;
+
+  corevm::runtime::closure_id closure_id = 10;
+  corevm::runtime::closure_id parent_closure_id = 100;
+
+  corevm::runtime::vector vector;
+
+  corevm::runtime::closure closure {
+    .id = closure_id,
+    .parent_id = parent_closure_id,
+    .vector = vector
+  };
+
+  corevm::runtime::closure parent_closure {
+    .id = parent_closure_id,
+    .parent_id = corevm::runtime::NONESET_CLOSURE_ID,
+    .vector = vector
+  };
+
+  frame.set_closure_id(closure_id);
+  parent_frame.set_closure_id(parent_closure_id);
+
+  m_process.insert_closure(closure);
+  m_process.insert_closure(parent_closure);
+
+  corevm::runtime::variable_key key = 123;
+  corevm::dyobj::dyobj_id id = 456;
+
+  parent_frame.set_visible_var(key, id);
+
+  m_process.push_frame(frame);
+  m_process.push_frame(parent_frame);
+
+  corevm::runtime::instr instr = {
+    .code=0,
+    .oprd1=static_cast<corevm::runtime::instr_oprd>(key),
+    .oprd2=0
+  };
+
+  execute_instr<corevm::runtime::instr_handler_ldobj>(instr, 1);
+
+  ASSERT_EQ(id, m_process.top_stack());
 }
 
 TEST_F(process_obj_instrs_test, TestInstrSTOBJ)

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -377,26 +377,6 @@ protected:
 };
 
 
-TEST_F(process_functions_instrs_test, TestInstrFRM)
-{
-  ASSERT_THROW(
-    {
-      m_process.top_frame();
-    },
-    corevm::runtime::frame_not_found_error
-  );
-
-  corevm::runtime::instr instr;
-  corevm::runtime::instr_handler_frm handler;
-  handler.execute(instr, m_process);
-
-  ASSERT_NO_THROW(
-    {
-      m_process.top_frame();
-    }
-  );
-}
-
 TEST_F(process_functions_instrs_test, TestInstrPUTARG)
 {
   corevm::runtime::frame frame;

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -227,7 +227,49 @@ TEST_F(process_obj_instrs_test, TestInstrPOP)
 
 TEST_F(process_obj_instrs_test, TestInstrLDOBJ2)
 {
-  // TODO: [COREVM-49] Complete instruction set and implementations
+  corevm::runtime::frame frame;
+  corevm::runtime::frame parent_frame;
+
+  corevm::runtime::closure_id closure_id = 10;
+  corevm::runtime::closure_id parent_closure_id = 100;
+
+  corevm::runtime::vector vector;
+
+  corevm::runtime::closure closure {
+    .id = closure_id,
+    .parent_id = parent_closure_id,
+    .vector = vector
+  };
+
+  corevm::runtime::closure parent_closure {
+    .id = parent_closure_id,
+    .parent_id = corevm::runtime::NONESET_CLOSURE_ID,
+    .vector = vector
+  };
+
+  frame.set_closure_id(closure_id);
+  parent_frame.set_closure_id(parent_closure_id);
+
+  m_process.insert_closure(closure);
+  m_process.insert_closure(parent_closure);
+
+  corevm::runtime::variable_key key = 123;
+  corevm::dyobj::dyobj_id id = 456;
+
+  parent_frame.set_invisible_var(key, id);
+
+  m_process.push_frame(frame);
+  m_process.push_frame(parent_frame);
+
+  corevm::runtime::instr instr = {
+    .code=0,
+    .oprd1=static_cast<corevm::runtime::instr_oprd>(key),
+    .oprd2=0
+  };
+
+  execute_instr<corevm::runtime::instr_handler_ldobj2>(instr, 1);
+
+  ASSERT_EQ(id, m_process.top_stack());
 }
 
 TEST_F(process_obj_instrs_test, TestInstrSTOBJ2)


### PR DESCRIPTION
Implement the ability for frames to be associated with closures, thus setting up a framework for scopes. Also, implemented the functionalities for the instructions `ldobj` and `ldobj2`, based on the new scoping capability.