### PR TITLE
[COREVM-118] Move bytecode_loader into public namespace

### DIFF
--- a/include/frontend/bytecode_loader.h
+++ b/include/frontend/bytecode_loader.h
@@ -46,7 +46,7 @@ public:
   virtual std::string schema() const = 0;
 
   static void load(const std::string&, corevm::runtime::process&)
-   throw(corevm::frontend::file_loading_error);
+    throw(corevm::frontend::file_loading_error);
 };
 
 

--- a/include/frontend/bytecode_loader_v0_1.h
+++ b/include/frontend/bytecode_loader_v0_1.h
@@ -20,8 +20,10 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#ifndef COREVM_BYTECODE_LOADER_H_
-#define COREVM_BYTECODE_LOADER_H_
+#ifndef COREVM_BYTECODE_LOADER_V0_1_H_
+#define COREVM_BYTECODE_LOADER_V0_1_H_
+
+#include "bytecode_loader.h"
 
 #include "errors.h"
 #include "../runtime/process.h"
@@ -40,13 +42,10 @@ namespace frontend {
 using sneaker::json::JSON;
 
 
-class bytecode_loader {
+class bytecode_loader_v0_1 : public corevm::frontend::bytecode_loader {
 public:
-  virtual void load(const JSON&, corevm::runtime::process&) = 0;
-  virtual std::string schema() const = 0;
-
-  static void load(const std::string&, corevm::runtime::process&)
-   throw(corevm::frontend::file_loading_error);
+  virtual void load(const JSON&, corevm::runtime::process&);
+  virtual std::string schema() const;
 };
 
 
@@ -56,4 +55,4 @@ public:
 } /* end namespace corevm */
 
 
-#endif /* COREVM_BYTECODE_LOADER_H_ */
+#endif /* COREVM_BYTECODE_LOADER_V0_1_H_ */

--- a/include/frontend/bytecode_loader_v0_1.h
+++ b/include/frontend/bytecode_loader_v0_1.h
@@ -25,7 +25,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "bytecode_loader.h"
 
-#include "errors.h"
 #include "../runtime/process.h"
 
 #include <sneaker/json/json.h>

--- a/src/frontend/bytecode_loader.cc
+++ b/src/frontend/bytecode_loader.cc
@@ -22,9 +22,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #include "../../include/frontend/bytecode_loader.h"
 
+#include "../../include/frontend/bytecode_loader_v0_1.h"
 #include "../../include/frontend/errors.h"
 #include "../../include/frontend/utils.h"
-#include "../../include/runtime/common.h"
 #include "../../include/runtime/process.h"
 #include "../../include/runtime/vector.h"
 
@@ -52,204 +52,6 @@ namespace frontend {
 
 
 namespace internal {
-
-
-class bytecode_loader {
-public:
-  virtual void load(const JSON&, corevm::runtime::process&) = 0;
-  virtual std::string schema() const = 0;
-};
-
-
-class bytecode_loader_v0_1 : public bytecode_loader {
-public:
-  virtual std::string schema() const
-  {
-    return \
-      "{"
-        "\"type\": \"object\","
-        "\"properties\": {"
-          "\"format\": {"
-            "\"type\": \"string\""
-          "},"
-          "\"format-version\": {"
-            "\"type\": \"string\""
-          "},"
-          "\"target-version\": {"
-            "\"type\": \"string\""
-          "},"
-          "\"path\": {"
-            "\"type\": \"string\""
-          "},"
-          "\"timestamp\": {"
-            "\"type\": \"string\","
-            "\"format\": \"date-time\""
-          "},"
-          "\"encoding\": {"
-            "\"type\": \"string\","
-            "\"enum\": ["
-              "\"utf8\""
-            "]"
-          "},"
-          "\"author\": {"
-            "\"type\": \"string\""
-          "},"
-          "\"encoding_map\": {"
-            "\"type\": \"array\","
-            "\"items\": {"
-              "\"$ref\": \"#/definitions/encoding_pair\""
-            "}"
-          "},"
-          "\"__MAIN__\": {"
-            "\"type\": \"array\","
-            "\"items\": {"
-              "\"$ref\": \"#/definitions/closure\""
-            "}"
-          "}"
-        "},"
-        "\"additionalProperties\": false,"
-        "\"required\": ["
-          "\"format\","
-          "\"format-version\","
-          "\"target-version\","
-          "\"encoding\","
-          "\"encoding_map\","
-          "\"__MAIN__\""
-        "],"
-        "\"definitions\": {"
-          "\"encoding_pair\": {"
-            "\"type\": \"object\","
-            "\"properties\": {"
-              "\"key\": {"
-                "\"type\": \"string\""
-              "},"
-              "\"value\": {"
-                "\"type\": \"integer\""
-              "}"
-            "}"
-          "},"
-          "\"instr\": {"
-            "\"type\": \"integer\","
-            "\"minimum\": 0,"
-            "\"maximum\": 4294967295"
-          "},"
-          "\"vector\": {"
-            "\"type:\": \"array\","
-            "\"items\": {"
-              "\"type:\": \"array\","
-              "\"items\": ["
-                "{"
-                  "\"$ref\": \"#/definitions/instr\""
-                "},"
-                "{"
-                  "\"$ref\": \"#/definitions/instr\""
-                "},"
-                "{"
-                  "\"$ref\": \"#/definitions/instr\""
-                "}"
-              "],"
-              "\"minItems\": 1,"
-              "\"maxItems\": 3,"
-              "\"additionalItems\": false"
-            "}"
-          "},"
-          "\"closure\": {"
-            "\"type\": \"object\","
-            "\"properties\": {"
-              "\"__name__\": {"
-                "\"type\": \"string\""
-              "},"
-              "\"__vector__\": {"
-                "\"$ref\": \"#/definitions/vector\""
-              "},"
-              "\"__parent__\": {"
-                "\"type\": \"string\""
-              "}"
-            "},"
-            "\"required\": ["
-              "\"__name__\","
-              "\"__vector__\""
-            "]"
-          "}"
-        "}"
-      "}";
-  }
-
-  virtual void load(const JSON& content_json, corevm::runtime::process& process)
-  {
-    const JSON::object& json_object = content_json.object_items();
-
-    // [COREVM-116] Implement mechanism to check bytecode format and target verisons
-    const JSON::string& format = json_object.at("format").string_value();
-    const JSON::string& format_version = json_object.at("format-version").string_value();
-    const JSON::string& target_version = json_object.at("target-version").string_value();
-    const JSON::string& encoding = json_object.at("encoding").string_value();
-
-    // Load encoding map.
-    const JSON::array& encoding_map = json_object.at("encoding_map").array_items();
-
-    for (auto itr = encoding_map.begin(); itr != encoding_map.end(); ++itr) {
-      const JSON& raw_encoding_pair = static_cast<JSON>(*itr);
-      const JSON::object& encoding_pair = raw_encoding_pair.object_items();
-
-      // Keys and values are flipped.
-      const JSON& raw_value = encoding_pair.at("key");
-      const JSON& raw_key = encoding_pair.at("value");
-
-      const std::string value = static_cast<std::string>(raw_value.string_value());
-      const uint64_t key = static_cast<uint64_t>(raw_key.int_value());
-
-      process.set_encoding_key_value_pair(key, value);
-    }
-
-    const JSON::array& closures = json_object.at("__MAIN__").array_items();
-
-    /* --------------------------- Load closures. --------------------------- */
-
-    // Translate local closure identifiers to global IDs.
-    std::unordered_map<std::string, corevm::runtime::closure_id> str_to_closure_id_map;
-
-    for (auto itr = closures.begin(); itr != closures.end(); ++itr) {
-      const JSON& closure_raw = static_cast<JSON>(*itr);
-      const JSON::object& closure = closure_raw.object_items();
-
-      const JSON::string& __name__ = closure.at("__name__").string_value();
-      const JSON& __vector__ = closure.at("__vector__");
-
-      const std::string name = static_cast<std::string>(__name__);
-      corevm::runtime::vector vector = corevm::frontend::get_vector_from_json(__vector__);
-
-      if (closure.find("__parent__") == closure.end()) {
-        process.append_vector(vector);
-        continue;
-      }
-
-      const JSON::string& __parent__ = closure.at("__parent__").string_value();
-      const std::string parent = static_cast<std::string>(__parent__);
-
-      if (str_to_closure_id_map.find(name) == str_to_closure_id_map.end()) {
-        str_to_closure_id_map[name] = process.get_new_closure_id();
-      }
-
-      if (str_to_closure_id_map.find(parent) == str_to_closure_id_map.end()) {
-        str_to_closure_id_map[parent] = \
-          parent.empty() ? corevm::runtime::NONESET_CLOSURE_ID : process.get_new_closure_id();
-      }
-
-      corevm::runtime::closure_id id = str_to_closure_id_map.at(name);
-      corevm::runtime::closure_id parent_id = str_to_closure_id_map.at(parent);
-
-      process.insert_closure(
-        corevm::runtime::closure {
-          .id = id,
-          .parent_id = parent_id,
-          .vector = vector
-        }
-      );
-    }
-  }
-
-}; /* end class bytecode_loader_v0_1 */
 
 
 typedef struct bytecode_loader_wrapper {
@@ -347,7 +149,8 @@ validate_and_load(const JSON& content_json, corevm::runtime::process& process)
 
 
 void
-corevm::frontend::load(const std::string& path, corevm::runtime::process& process)
+corevm::frontend::bytecode_loader::load(
+  const std::string& path, corevm::runtime::process& process)
   throw(corevm::frontend::file_loading_error)
 {
   std::ifstream f(path, std::ios::binary);

--- a/src/frontend/bytecode_loader_v0_1.cc
+++ b/src/frontend/bytecode_loader_v0_1.cc
@@ -1,0 +1,225 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Yanzheng Li
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+#include "../../include/frontend/bytecode_loader_v0_1.h"
+
+#include "../../include/frontend/errors.h"
+#include "../../include/frontend/utils.h"
+#include "../../include/runtime/closure.h"
+#include "../../include/runtime/common.h"
+#include "../../include/runtime/process.h"
+#include "../../include/runtime/vector.h"
+
+#include <sneaker/json/json.h>
+#include <sneaker/json/json_schema.h>
+
+#include <string>
+
+
+std::string
+corevm::frontend::bytecode_loader_v0_1::schema() const
+{
+  return \
+    "{"
+      "\"type\": \"object\","
+      "\"properties\": {"
+        "\"format\": {"
+          "\"type\": \"string\""
+        "},"
+        "\"format-version\": {"
+          "\"type\": \"string\""
+        "},"
+        "\"target-version\": {"
+          "\"type\": \"string\""
+        "},"
+        "\"path\": {"
+          "\"type\": \"string\""
+        "},"
+        "\"timestamp\": {"
+          "\"type\": \"string\","
+          "\"format\": \"date-time\""
+        "},"
+        "\"encoding\": {"
+          "\"type\": \"string\","
+          "\"enum\": ["
+            "\"utf8\""
+          "]"
+        "},"
+        "\"author\": {"
+          "\"type\": \"string\""
+        "},"
+        "\"encoding_map\": {"
+          "\"type\": \"array\","
+          "\"items\": {"
+            "\"$ref\": \"#/definitions/encoding_pair\""
+          "}"
+        "},"
+        "\"__MAIN__\": {"
+          "\"type\": \"array\","
+          "\"items\": {"
+            "\"$ref\": \"#/definitions/closure\""
+          "}"
+        "}"
+      "},"
+      "\"additionalProperties\": false,"
+      "\"required\": ["
+        "\"format\","
+        "\"format-version\","
+        "\"target-version\","
+        "\"encoding\","
+        "\"encoding_map\","
+        "\"__MAIN__\""
+      "],"
+      "\"definitions\": {"
+        "\"encoding_pair\": {"
+          "\"type\": \"object\","
+          "\"properties\": {"
+            "\"key\": {"
+              "\"type\": \"string\""
+            "},"
+            "\"value\": {"
+              "\"type\": \"integer\""
+            "}"
+          "}"
+        "},"
+        "\"instr\": {"
+          "\"type\": \"integer\","
+          "\"minimum\": 0,"
+          "\"maximum\": 4294967295"
+        "},"
+        "\"vector\": {"
+          "\"type:\": \"array\","
+          "\"items\": {"
+            "\"type:\": \"array\","
+            "\"items\": ["
+              "{"
+                "\"$ref\": \"#/definitions/instr\""
+              "},"
+              "{"
+                "\"$ref\": \"#/definitions/instr\""
+              "},"
+              "{"
+                "\"$ref\": \"#/definitions/instr\""
+              "}"
+            "],"
+            "\"minItems\": 1,"
+            "\"maxItems\": 3,"
+            "\"additionalItems\": false"
+          "}"
+        "},"
+        "\"closure\": {"
+          "\"type\": \"object\","
+          "\"properties\": {"
+            "\"__name__\": {"
+              "\"type\": \"string\""
+            "},"
+            "\"__vector__\": {"
+              "\"$ref\": \"#/definitions/vector\""
+            "},"
+            "\"__parent__\": {"
+              "\"type\": \"string\""
+            "}"
+          "},"
+          "\"required\": ["
+            "\"__name__\","
+            "\"__vector__\""
+          "]"
+        "}"
+      "}"
+    "}";
+}
+
+void
+corevm::frontend::bytecode_loader_v0_1::load(
+  const JSON& content_json, corevm::runtime::process& process)
+{
+  const JSON::object& json_object = content_json.object_items();
+
+  // [COREVM-116] Implement mechanism to check bytecode format and target verisons
+  const JSON::string& format = json_object.at("format").string_value();
+  const JSON::string& format_version = json_object.at("format-version").string_value();
+  const JSON::string& target_version = json_object.at("target-version").string_value();
+  const JSON::string& encoding = json_object.at("encoding").string_value();
+
+  // Load encoding map.
+  const JSON::array& encoding_map = json_object.at("encoding_map").array_items();
+
+  for (auto itr = encoding_map.begin(); itr != encoding_map.end(); ++itr) {
+    const JSON& raw_encoding_pair = static_cast<JSON>(*itr);
+    const JSON::object& encoding_pair = raw_encoding_pair.object_items();
+
+    // Keys and values are flipped.
+    const JSON& raw_value = encoding_pair.at("key");
+    const JSON& raw_key = encoding_pair.at("value");
+
+    const std::string value = static_cast<std::string>(raw_value.string_value());
+    const uint64_t key = static_cast<uint64_t>(raw_key.int_value());
+
+    process.set_encoding_key_value_pair(key, value);
+  }
+
+  const JSON::array& closures = json_object.at("__MAIN__").array_items();
+
+  /* --------------------------- Load closures. --------------------------- */
+
+  // Translate local closure identifiers to global IDs.
+  std::unordered_map<std::string, corevm::runtime::closure_id> str_to_closure_id_map;
+
+  for (auto itr = closures.begin(); itr != closures.end(); ++itr) {
+    const JSON& closure_raw = static_cast<JSON>(*itr);
+    const JSON::object& closure = closure_raw.object_items();
+
+    const JSON::string& __name__ = closure.at("__name__").string_value();
+    const JSON& __vector__ = closure.at("__vector__");
+
+    const std::string name = static_cast<std::string>(__name__);
+    corevm::runtime::vector vector = corevm::frontend::get_vector_from_json(__vector__);
+
+    if (closure.find("__parent__") == closure.end()) {
+      process.append_vector(vector);
+      continue;
+    }
+
+    const JSON::string& __parent__ = closure.at("__parent__").string_value();
+    const std::string parent = static_cast<std::string>(__parent__);
+
+    if (str_to_closure_id_map.find(name) == str_to_closure_id_map.end()) {
+      str_to_closure_id_map[name] = process.get_new_closure_id();
+    }
+
+    if (str_to_closure_id_map.find(parent) == str_to_closure_id_map.end()) {
+      str_to_closure_id_map[parent] = \
+        parent.empty() ? corevm::runtime::NONESET_CLOSURE_ID : process.get_new_closure_id();
+    }
+
+    corevm::runtime::closure_id id = str_to_closure_id_map.at(name);
+    corevm::runtime::closure_id parent_id = str_to_closure_id_map.at(parent);
+
+    process.insert_closure(
+      corevm::runtime::closure {
+        .id = id,
+        .parent_id = parent_id,
+        .vector = vector
+      }
+    );
+  }
+}

--- a/tests/frontend/bytecode_loader_unittest.cc
+++ b/tests/frontend/bytecode_loader_unittest.cc
@@ -20,103 +20,15 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include "../../include/frontend/bytecode_loader.h"
+#include "bytecode_loader_unittest.h"
 
+#include "../../include/frontend/bytecode_loader.h"
 #include "../../include/runtime/process.h"
 
 #include <sneaker/testing/_unittest.h>
 
-#include <cassert>
-#include <fstream>
 #include <string>
 
-
-class bytecode_loader_unittest : public ::testing::Test {
-protected:
-  static const char* PATH;
-
-  virtual void SetUp() {
-    std::ofstream f(PATH, std::ios::binary);
-    f << this->bytecode();
-    f.close();
-  }
-
-  virtual void TearDown() {
-    remove(PATH);
-  }
-
-  virtual const char* bytecode() {
-    return "";
-  }
-};
-
-
-const char* bytecode_loader_unittest::PATH = "./example.corevm";
-
-
-class bytecode_loader_v0_1_unittest : public bytecode_loader_unittest {
-protected:
-  virtual const char* bytecode() {
-    return \
-    "{"
-      "\"format\": \"corevm\","
-      "\"format-version\": \"0.1\","
-      "\"target-version\": \"0.1\","
-      "\"path\": \"./example.corevm\","
-      "\"timestamp\": \"2014-10-12T15:33:30\","
-      "\"encoding\": \"utf8\","
-      "\"author\": \"Yanzheng Li\","
-      "\"encoding_map\": ["
-        "{"
-          "\"key\": \"name\","
-          "\"value\": 111"
-        "}"
-      "],"
-      "\"__MAIN__\": ["
-        "{"
-          "\"__name__\": \"hello_world\","
-          "\"__vector__\": ["
-            "[701, 702, 703],"
-            "[801, 802, 803],"
-            "[901, 902, 903]"
-          "],"
-          "\"__parent__\": \"hello_world_decorator\""
-        "},"
-        "{"
-          "\"__name__\": \"hello_world_decorator\","
-          "\"__vector__\": ["
-            "[701, 702, 703],"
-            "[801, 802, 803],"
-            "[901, 902, 903]"
-          "],"
-          "\"__parent__\": \"__main__\""
-        "},"
-        "{"
-          "\"__name__\": \"__main__\","
-          "\"__vector__\": ["
-            "[701, 702, 703],"
-            "[801, 802, 803],"
-            "[901, 902, 903]"
-          "]"
-        "}"
-      "]"
-    "}";
-  }
-};
-
-
-TEST_F(bytecode_loader_v0_1_unittest, TestLoadSuccessful)
-{
-  corevm::runtime::process process;
-
-  ASSERT_NO_THROW(
-    {
-      corevm::frontend::load(PATH, process);
-    }
-  );
-
-  ASSERT_EQ(2, process.closure_count());
-}
 
 TEST_F(bytecode_loader_unittest, TestLoadFailsWithInvalidPath)
 {
@@ -125,7 +37,7 @@ TEST_F(bytecode_loader_unittest, TestLoadFailsWithInvalidPath)
 
   ASSERT_THROW(
     {
-      corevm::frontend::load(invalid_path, process);
+      corevm::frontend::bytecode_loader::load(invalid_path, process);
     },
     corevm::frontend::file_loading_error
   );

--- a/tests/frontend/bytecode_loader_unittest.h
+++ b/tests/frontend/bytecode_loader_unittest.h
@@ -20,40 +20,34 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#ifndef COREVM_BYTECODE_LOADER_H_
-#define COREVM_BYTECODE_LOADER_H_
+#ifndef COREVM_BYTECODE_LOADER_UNITTEST_H_
+#define COREVM_BYTECODE_LOADER_UNITTEST_H_
 
-#include "errors.h"
-#include "../runtime/process.h"
+#include <sneaker/testing/_unittest.h>
 
-#include <sneaker/json/json.h>
-
-#include <string>
+#include <fstream>
 
 
-namespace corevm {
+class bytecode_loader_unittest : public ::testing::Test {
+protected:
+  static const char* PATH;
 
+  virtual void SetUp() {
+    std::ofstream f(PATH, std::ios::binary);
+    f << this->bytecode();
+    f.close();
+  }
 
-namespace frontend {
+  virtual void TearDown() {
+    remove(PATH);
+  }
 
-
-using sneaker::json::JSON;
-
-
-class bytecode_loader {
-public:
-  virtual void load(const JSON&, corevm::runtime::process&) = 0;
-  virtual std::string schema() const = 0;
-
-  static void load(const std::string&, corevm::runtime::process&)
-   throw(corevm::frontend::file_loading_error);
+  virtual const char* bytecode() {
+    return "";
+  }
 };
 
-
-} /* end namespace frontend */
-
-
-} /* end namespace corevm */
+const char* bytecode_loader_unittest::PATH = "./example.corevm";
 
 
-#endif /* COREVM_BYTECODE_LOADER_H_ */
+#endif /* COREVM_BYTECODE_LOADER_UNITTEST_H_ */

--- a/tests/frontend/bytecode_loader_v0_1_unittest.cc
+++ b/tests/frontend/bytecode_loader_v0_1_unittest.cc
@@ -1,0 +1,96 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Yanzheng Li
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+#include "bytecode_loader_unittest.h"
+
+#include "../../include/frontend/bytecode_loader_v0_1.h"
+#include "../../include/runtime/process.h"
+
+#include <sneaker/testing/_unittest.h>
+
+#include <cassert>
+#include <string>
+
+
+class bytecode_loader_v0_1_unittest : public bytecode_loader_unittest {
+protected:
+  virtual const char* bytecode() {
+    return \
+    "{"
+      "\"format\": \"corevm\","
+      "\"format-version\": \"0.1\","
+      "\"target-version\": \"0.1\","
+      "\"path\": \"./example.corevm\","
+      "\"timestamp\": \"2014-10-12T15:33:30\","
+      "\"encoding\": \"utf8\","
+      "\"author\": \"Yanzheng Li\","
+      "\"encoding_map\": ["
+        "{"
+          "\"key\": \"name\","
+          "\"value\": 111"
+        "}"
+      "],"
+      "\"__MAIN__\": ["
+        "{"
+          "\"__name__\": \"hello_world\","
+          "\"__vector__\": ["
+            "[701, 702, 703],"
+            "[801, 802, 803],"
+            "[901, 902, 903]"
+          "],"
+          "\"__parent__\": \"hello_world_decorator\""
+        "},"
+        "{"
+          "\"__name__\": \"hello_world_decorator\","
+          "\"__vector__\": ["
+            "[701, 702, 703],"
+            "[801, 802, 803],"
+            "[901, 902, 903]"
+          "],"
+          "\"__parent__\": \"__main__\""
+        "},"
+        "{"
+          "\"__name__\": \"__main__\","
+          "\"__vector__\": ["
+            "[701, 702, 703],"
+            "[801, 802, 803],"
+            "[901, 902, 903]"
+          "]"
+        "}"
+      "]"
+    "}";
+  }
+};
+
+
+TEST_F(bytecode_loader_v0_1_unittest, TestLoadSuccessful)
+{
+  corevm::runtime::process process;
+
+  ASSERT_NO_THROW(
+    {
+      corevm::frontend::bytecode_loader::load(PATH, process);
+    }
+  );
+
+  ASSERT_EQ(2, process.closure_count());
+}

--- a/tests/frontend/bytecode_loader_v0_1_unittest.cc
+++ b/tests/frontend/bytecode_loader_v0_1_unittest.cc
@@ -27,7 +27,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <sneaker/testing/_unittest.h>
 
-#include <cassert>
 #include <string>
 
 


### PR DESCRIPTION
Currently `corevm::frontend::internal::bytecode_loader` lives in a private namespace. It's better to move it out to the public namespace so that derived classes of the loader for future versions can live in separate files and still be able to inherit from it. 