### PR TITLE
[COREVM-116] Implement mechanism to check bytecode format and target verisons

### DIFF
--- a/include/frontend/bytecode_loader.h
+++ b/include/frontend/bytecode_loader.h
@@ -43,6 +43,8 @@ using sneaker::json::JSON;
 class bytecode_loader {
 public:
   virtual void load(const JSON&, corevm::runtime::process&) = 0;
+  virtual std::string format() const = 0;
+  virtual std::string version() const = 0;
   virtual std::string schema() const = 0;
 
   static void load(const std::string&, corevm::runtime::process&)

--- a/include/version.h
+++ b/include/version.h
@@ -30,11 +30,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // COREVM_VERSION % 100 is the patch level.
 // COREVM_VERSION / 100 % 1000 is the minor version.
 // COREVM_VERSION / 100000 is the major version.
-#define COREVM_VERSION 000100
+#define COREVM_VERSION 001000
 
 
 // Canonical version.
-#define COREVM_CANONICAL_VERSION "0.0.1"
+#define COREVM_CANONICAL_VERSION "0.1.0"
 
 
 // Short canonical version.

--- a/include/version.h
+++ b/include/version.h
@@ -33,8 +33,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define COREVM_VERSION 000100
 
 
-// Canonical version of library.
-#define COREVM_LIB_VERSION "0.0.1"
+// Canonical version.
+#define COREVM_CANONICAL_VERSION "0.0.1"
+
+
+// Short canonical version.
+#define COREVM_SHORT_CANONICAL_VERSION "0.1"
 
 
 #endif /* _COREVM_VERSION_H_ */

--- a/include/version.h
+++ b/include/version.h
@@ -20,40 +20,21 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#ifndef COREVM_BYTECODE_LOADER_V0_1_H_
-#define COREVM_BYTECODE_LOADER_V0_1_H_
 
-#include "bytecode_loader.h"
+/* Defines build version number */
 
-#include "../runtime/process.h"
-
-#include <sneaker/json/json.h>
-
-#include <string>
+#ifndef _COREVM_VERSION_H_
+#define _COREVM_VERSION_H_
 
 
-namespace corevm {
+// COREVM_VERSION % 100 is the patch level.
+// COREVM_VERSION / 100 % 1000 is the minor version.
+// COREVM_VERSION / 100000 is the major version.
+#define COREVM_VERSION 000100
 
 
-namespace frontend {
+// Canonical version of library.
+#define COREVM_LIB_VERSION "0.0.1"
 
 
-using sneaker::json::JSON;
-
-
-class bytecode_loader_v0_1 : public corevm::frontend::bytecode_loader {
-public:
-  virtual void load(const JSON&, corevm::runtime::process&);
-  virtual std::string format() const;
-  virtual std::string version() const;
-  virtual std::string schema() const;
-};
-
-
-} /* end namespace frontend */
-
-
-} /* end namespace corevm */
-
-
-#endif /* COREVM_BYTECODE_LOADER_V0_1_H_ */
+#endif /* _COREVM_VERSION_H_ */

--- a/src/frontend/bytecode_loader.cc
+++ b/src/frontend/bytecode_loader.cc
@@ -22,6 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #include "../../include/frontend/bytecode_loader.h"
 
+#include "../../include/version.h"
 #include "../../include/frontend/bytecode_loader_v0_1.h"
 #include "../../include/frontend/errors.h"
 #include "../../include/frontend/utils.h"
@@ -125,8 +126,15 @@ validate_and_load(const JSON& content_json, corevm::runtime::process& process)
 {
   const JSON::object& json_object = content_json.object_items();
 
-  if (json_object.find("format-version") == json_object.end()) {
-    throw corevm::frontend::file_loading_error("Missing \"format-version\" in file");
+  const JSON::string& target_version = json_object.at("target-version").string_value();
+  const std::string target_version_str = static_cast<std::string>(target_version);
+
+  if (target_version_str != COREVM_SHORT_CANONICAL_VERSION) {
+    throw corevm::frontend::file_loading_error(
+      str(
+        boost::format("Invalid target-version: %s") % target_version_str
+      )
+    );
   }
 
   const JSON::string& format = json_object.at("format").string_value();
@@ -140,8 +148,6 @@ validate_and_load(const JSON& content_json, corevm::runtime::process& process)
   );
 
   const std::string& schema = loader->schema();
-
-  // TODO: validate `target-version` field.
 
   const JSON schema_json = sneaker::json::parse(schema);
 

--- a/src/frontend/bytecode_loader.cc
+++ b/src/frontend/bytecode_loader.cc
@@ -55,14 +55,15 @@ namespace internal {
 
 
 typedef struct bytecode_loader_wrapper {
-  const std::string version;
   bytecode_loader* loader;
 } bytecode_loader_wrapper;
 
 
 class schema_repository {
 public:
-  static const bytecode_loader_wrapper load_by_format_version(const std::string&);
+  static bytecode_loader* load_by_format_and_version(
+    const std::string&, const std::string&);
+
 private:
   static const std::vector<bytecode_loader_wrapper> bytecode_loader_definitions;
 };
@@ -71,25 +72,44 @@ private:
 const std::vector<bytecode_loader_wrapper>
 corevm::frontend::internal::schema_repository::bytecode_loader_definitions {
   {
-    .version = "0.1",
     .loader = new bytecode_loader_v0_1(),
-  }, /* end 0.1 */
+  },
 };
 
 
-const bytecode_loader_wrapper
-corevm::frontend::internal::schema_repository::load_by_format_version(
-  const std::string& format_version)
+bytecode_loader*
+corevm::frontend::internal::schema_repository::load_by_format_and_version(
+  const std::string& format, const std::string& format_version)
 {
-  auto itr = std::find_if(
+  std::list<bytecode_loader*> loaders;
+
+  std::for_each(
     bytecode_loader_definitions.begin(),
     bytecode_loader_definitions.end(),
-    [&format_version](const bytecode_loader_wrapper& wrapper) -> bool {
-      return wrapper.version == format_version;
+    [&format, &loaders](const bytecode_loader_wrapper& wrapper) {
+      if (wrapper.loader->format() == format) {
+        loaders.push_back(wrapper.loader);
+      }
     }
   );
 
-  if (itr == bytecode_loader_definitions.end()) {
+  if (loaders.empty()) {
+    throw file_loading_error(
+      str(
+        boost::format("Unrecognized format: \"%s\"") % format
+      )
+    );
+  }
+
+  auto itr = std::find_if(
+    loaders.begin(),
+    loaders.end(),
+    [&format_version](const bytecode_loader* loader) -> bool {
+      return loader->version() == format_version;
+    }
+  );
+
+  if (itr == loaders.end()) {
     throw file_loading_error(
       str(
         boost::format("Unrecognized format-version: \"%s\"") % format_version
@@ -97,7 +117,7 @@ corevm::frontend::internal::schema_repository::load_by_format_version(
     );
   }
 
-  return static_cast<bytecode_loader_wrapper>(*itr);
+  return static_cast<bytecode_loader*>(*itr);
 }
 
 void
@@ -109,14 +129,16 @@ validate_and_load(const JSON& content_json, corevm::runtime::process& process)
     throw corevm::frontend::file_loading_error("Missing \"format-version\" in file");
   }
 
+  const JSON::string& format = json_object.at("format").string_value();
   const JSON::string& format_version = json_object.at("format-version").string_value();
+
+  const std::string format_str = static_cast<std::string>(format);
   const std::string format_version_str = static_cast<std::string>(format_version);
 
-  const auto wrapper = corevm::frontend::internal::schema_repository::load_by_format_version(
-    format_version_str
+  bytecode_loader* loader = corevm::frontend::internal::schema_repository::load_by_format_and_version(
+    format_str, format_version_str
   );
 
-  bytecode_loader* loader = wrapper.loader;
   const std::string& schema = loader->schema();
 
   // TODO: validate `target-version` field.

--- a/src/frontend/bytecode_loader_v0_1.cc
+++ b/src/frontend/bytecode_loader_v0_1.cc
@@ -35,6 +35,23 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <string>
 
 
+const std::string BYTECODE_LOADER_V0_1_FORMAT = "nucleus";
+
+const std::string BYTECODE_LOADER_V0_1_VERSION = "0.1";
+
+
+std::string
+corevm::frontend::bytecode_loader_v0_1::format() const
+{
+  return BYTECODE_LOADER_V0_1_FORMAT;
+}
+
+std::string
+corevm::frontend::bytecode_loader_v0_1::version() const
+{
+  return BYTECODE_LOADER_V0_1_VERSION;
+}
+
 std::string
 corevm::frontend::bytecode_loader_v0_1::schema() const
 {

--- a/src/frontend/bytecode_loader_v0_1.cc
+++ b/src/frontend/bytecode_loader_v0_1.cc
@@ -35,7 +35,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <string>
 
 
-const std::string BYTECODE_LOADER_V0_1_FORMAT = "nucleus";
+const std::string BYTECODE_LOADER_V0_1_FORMAT = "application/json";
 
 const std::string BYTECODE_LOADER_V0_1_VERSION = "0.1";
 
@@ -66,7 +66,8 @@ corevm::frontend::bytecode_loader_v0_1::schema() const
           "\"type\": \"string\""
         "},"
         "\"target-version\": {"
-          "\"type\": \"string\""
+          "\"type\": \"string\","
+          "\"pattern\": \"(0|1|2|3|4|5|6|7|8|9)(\.)(0|1|2|3|4|5|6|7|8|9)\""
         "},"
         "\"path\": {"
           "\"type\": \"string\""
@@ -171,10 +172,6 @@ corevm::frontend::bytecode_loader_v0_1::load(
 {
   const JSON::object& json_object = content_json.object_items();
 
-  // [COREVM-116] Implement mechanism to check bytecode format and target verisons
-  const JSON::string& format = json_object.at("format").string_value();
-  const JSON::string& format_version = json_object.at("format-version").string_value();
-  const JSON::string& target_version = json_object.at("target-version").string_value();
   const JSON::string& encoding = json_object.at("encoding").string_value();
 
   // Load encoding map.

--- a/tests/frontend/bytecode_loader_v0_1_unittest.cc
+++ b/tests/frontend/bytecode_loader_v0_1_unittest.cc
@@ -35,7 +35,7 @@ protected:
   virtual const char* bytecode() {
     return \
     "{"
-      "\"format\": \"corevm\","
+      "\"format\": \"nucleus\","
       "\"format-version\": \"0.1\","
       "\"target-version\": \"0.1\","
       "\"path\": \"./example.corevm\","

--- a/tests/frontend/bytecode_loader_v0_1_unittest.cc
+++ b/tests/frontend/bytecode_loader_v0_1_unittest.cc
@@ -35,7 +35,7 @@ protected:
   virtual const char* bytecode() {
     return \
     "{"
-      "\"format\": \"nucleus\","
+      "\"format\": \"application/json\","
       "\"format-version\": \"0.1\","
       "\"target-version\": \"0.1\","
       "\"path\": \"./example.corevm\","
@@ -85,11 +85,7 @@ TEST_F(bytecode_loader_v0_1_unittest, TestLoadSuccessful)
 {
   corevm::runtime::process process;
 
-  ASSERT_NO_THROW(
-    {
-      corevm::frontend::bytecode_loader::load(PATH, process);
-    }
-  );
+  corevm::frontend::bytecode_loader::load(PATH, process);
 
   ASSERT_EQ(2, process.closure_count());
 }


### PR DESCRIPTION
In #48 we implemented the mechanism to load bytecode into the process. However, we left the target and format version in the bytecode unchecked. This patch adds a mechanism to validate against these values.

The specific fields to validate against are `format` and `target-version`.