### PR TITLE
[COREVM-119] Decouple process from thread daemon

### DIFF
--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -37,7 +37,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../../include/gc/garbage_collection_scheme.h"
 
 #include <sneaker/atomic/atomic_incrementor.h>
-#include <sneaker/threading/fixed_time_interval_daemon_service.h>
 
 #include <climits>
 #include <cstdint>
@@ -67,7 +66,7 @@ namespace runtime {
  * - A table for storing closures.
  * - An incrementor for closure IDs.
  */
-class process : public sneaker::threading::fixed_time_interval_daemon_service {
+class process {
 
 public:
   typedef corevm::gc::reference_count_garbage_collection_scheme garbage_collection_scheme;
@@ -94,7 +93,6 @@ public:
 
 public:
   explicit process();
-  explicit process(const uint16_t);
   ~process();
 
   const corevm::runtime::instr_addr top_addr() const;
@@ -152,7 +150,7 @@ public:
 
   void get_frame_by_closure_id(corevm::runtime::closure_id, corevm::runtime::frame**);
 
-  virtual bool start();
+  void start();
 
   void maybe_gc();
 
@@ -179,8 +177,6 @@ public:
   native_types_pool_type::size_type max_ntvhndl_pool_size() const;
 
 private:
-  static void tick_handler(void*);
-
   bool should_gc();
 
   void insert_vector(corevm::runtime::vector& vector);

--- a/include/runtime/process_runner.h
+++ b/include/runtime/process_runner.h
@@ -1,0 +1,57 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Yanzheng Li
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+#ifndef COREVM_PROCESS_RUNNER_H_
+#define COREVM_PROCESS_RUNNER_H_
+
+#include "process.h"
+
+#include <sneaker/threading/fixed_time_interval_daemon_service.h>
+
+
+namespace corevm {
+
+
+namespace runtime {
+
+
+class process_runner : public sneaker::threading::fixed_time_interval_daemon_service {
+public:
+  explicit process_runner(corevm::runtime::process&);
+
+  bool start();
+
+protected:
+  static void tick_handler(void*);
+
+  void gc();
+
+  corevm::runtime::process& m_process;
+};
+
+
+}; /* end namespace runtime */
+
+
+}; /* end namespace corevm */
+
+#endif /* COREVM_PROCESS_RUNNER_H_ */

--- a/include/runtime/process_runner.h
+++ b/include/runtime/process_runner.h
@@ -54,4 +54,5 @@ protected:
 
 }; /* end namespace corevm */
 
+
 #endif /* COREVM_PROCESS_RUNNER_H_ */

--- a/src/runtime/process_runner.cc
+++ b/src/runtime/process_runner.cc
@@ -1,0 +1,74 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Yanzheng Li
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+#include "../../include/runtime/process_runner.h"
+
+#include "../../include/runtime/process.h"
+
+#include <sneaker/threading/fixed_time_interval_daemon_service.h>
+
+
+const int COREVM_PROCESS_DEFAULT_PAUSE_TIME = 10;
+
+
+const int COREVM_PROCESS_DEFAULT_MAX_RUN_ITERATIONS = -1;
+
+
+corevm::runtime::process_runner::process_runner(
+  corevm::runtime::process& process
+) :
+  sneaker::threading::fixed_time_interval_daemon_service(
+    COREVM_PROCESS_DEFAULT_PAUSE_TIME,
+    corevm::runtime::process_runner::tick_handler,
+    false,
+    COREVM_PROCESS_DEFAULT_MAX_RUN_ITERATIONS
+  ),
+  m_process(process)
+{
+  // Do nothing here.
+}
+
+bool
+corevm::runtime::process_runner::start()
+{
+  bool res = sneaker::threading::fixed_time_interval_daemon_service::start();
+
+  if (res) {
+    m_process.start();
+  }
+
+  return res;
+}
+
+void
+corevm::runtime::process_runner::tick_handler(void* arg)
+{
+  assert(arg);
+  corevm::runtime::process_runner* runner = static_cast<corevm::runtime::process_runner*>(arg);
+  runner->gc();
+}
+
+void
+corevm::runtime::process_runner::gc()
+{
+  m_process.maybe_gc();
+}

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -25,6 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../../include/runtime/common.h"
 #include "../../include/runtime/gc_rule.h"
 #include "../../include/runtime/process.h"
+#include "../../include/runtime/process_runner.h"
 #include "../../include/runtime/sighandler_registrar.h"
 #include "../../include/runtime/vector.h"
 
@@ -41,19 +42,16 @@ TEST_F(process_unittest, TestInitialization)
   corevm::runtime::process process;
 }
 
-TEST_F(process_unittest, TestInitializationWithArgs)
-{
-  corevm::runtime::process process(1);
-}
-
 TEST_F(process_unittest, TestStart)
 {
   // TODO: [COREVM-117] Process start causes seg fault
 
+
   /******************************** DISABLED ***********************************
 
-  corevm::runtime::process process(1);
-  process.start();
+  corevm::runtime::process process;
+  corevm::runtime::process_runner runner(process);
+  runner.start();
 
   ******************************** DISABLED ***********************************/
 }


### PR DESCRIPTION
Currently, `corevm::runtime::process` inherits from `sneaker::threading::fixed_time_interval_daemon_service`. This design tightly couples process with the daemon, which makes development on the both components hard. Let's break this coupling into separate components. 