### PR TITLE
[COREVM-124] Make dynamic objects non-copyable

### DIFF
--- a/include/dyobj/dynamic_object.h
+++ b/include/dyobj/dynamic_object.h
@@ -56,6 +56,10 @@ public:
 
   explicit dynamic_object();
 
+  /* Dynamic objects should not be copyable. */
+  dynamic_object(const dynamic_object&) = delete;
+  dynamic_object& operator=(const dynamic_object&) = delete;
+
   ~dynamic_object();
 
   bool operator==(const corevm::dyobj::dynamic_object<dynamic_object_manager>&);
@@ -151,7 +155,7 @@ bool
 corevm::dyobj::dynamic_object<dynamic_object_manager>::operator!=(
   const corevm::dyobj::dynamic_object<dynamic_object_manager>& rhs)
 {
-  return !(static_cast<corevm::dyobj::dynamic_object<dynamic_object_manager>>(*this) == rhs);
+  return !((*this) == rhs);
 }
 
 template<class dynamic_object_manager>

--- a/include/dyobj/dynamic_object_heap.h
+++ b/include/dyobj/dynamic_object_heap.h
@@ -35,6 +35,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <algorithm>
 #include <stdexcept>
 
+
 namespace corevm {
 
 

--- a/include/memory/object_container.h
+++ b/include/memory/object_container.h
@@ -279,8 +279,7 @@ corevm::memory::object_container<T, AllocatorType>::create()
     return nullptr;
   }
 
-  T t;
-  m_allocator.construct(p, t);
+  m_allocator.construct(p);
 
   m_addrs.insert(p);
 

--- a/src/gc/mark_and_sweep_garbage_collection_scheme.cc
+++ b/src/gc/mark_and_sweep_garbage_collection_scheme.cc
@@ -35,7 +35,7 @@ corevm::gc::mark_and_sweep_garbage_collection_scheme::gc(
   heap.iterate(
     [this, &heap](
       _dynamic_object_heap_type::dynamic_object_id_type id,
-      _dynamic_object_heap_type::dynamic_object_type object
+      _dynamic_object_heap_type::dynamic_object_type& object
     ) {
       if (this->is_root_object(object)) {
         this->mark(heap, object);

--- a/src/gc/reference_count_garbage_collection_scheme.cc
+++ b/src/gc/reference_count_garbage_collection_scheme.cc
@@ -42,7 +42,7 @@ corevm::gc::reference_count_garbage_collection_scheme::gc(
     heap.iterate(
       [this, &heap](
         _dynamic_object_heap_type::dynamic_object_id_type id,
-        _dynamic_object_heap_type::dynamic_object_type object
+        _dynamic_object_heap_type::dynamic_object_type& object
       ) {
         this->check_and_dec_ref_count(heap, object);
         this->resolve_self_reference_cycles(heap, object);
@@ -135,7 +135,7 @@ corevm::gc::reference_count_garbage_collection_scheme::remove_cycles(
   heap.iterate(
     [&](
       dynamic_object_heap_type::dynamic_object_id_type id,
-      dynamic_object_heap_type::dynamic_object_type object
+      dynamic_object_heap_type::dynamic_object_type& object
     ) {
       if (object.get_flag(corevm::dyobj::flags::IS_NOT_GARBAGE_COLLECTIBLE) == true) {
         object.iterate(

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -435,8 +435,8 @@ TEST_F(process_obj_instrs_test, TestInstrCLRHNDL)
   corevm::runtime::instr instr;
   execute_instr<corevm::runtime::instr_handler_clrhndl>(instr, 1);
 
-  obj = process::adapter(m_process).help_get_dyobj(id);
-  ASSERT_EQ(corevm::dyobj::NONESET_NTVHNDL_KEY, obj.get_ntvhndl_key());
+  auto &obj2 = process::adapter(m_process).help_get_dyobj(id);
+  ASSERT_EQ(corevm::dyobj::NONESET_NTVHNDL_KEY, obj2.get_ntvhndl_key());
 
   ASSERT_FALSE(m_process.has_ntvhndl(ntvhndl_key));
 }


### PR DESCRIPTION
Dynamic objects should not be copyable, from both a semantics and performance perspectives.