### PR TITLE
[COREVM-128] Implement "invk" instruction

### DIFF
--- a/include/runtime/frame.h
+++ b/include/runtime/frame.h
@@ -61,8 +61,6 @@ public:
 
   corevm::runtime::instr_addr get_start_addr() const;
 
-  void set_start_addr(const corevm::runtime::instr_addr);
-
   corevm::runtime::instr_addr get_return_addr() const;
 
   void set_return_addr(const corevm::runtime::instr_addr);
@@ -115,7 +113,6 @@ public:
 
 protected:
   const corevm::runtime::closure_ctx m_closure_ctx;
-  corevm::runtime::instr_addr m_start_addr;
   corevm::runtime::instr_addr m_return_addr;
   std::unordered_map<corevm::runtime::variable_key, corevm::dyobj::dyobj_id> m_visible_vars;
   std::unordered_map<corevm::runtime::variable_key, corevm::dyobj::dyobj_id> m_invisible_vars;

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -126,13 +126,13 @@ enum instr_enum : uint32_t
   //------------------------- Control instructions ----------------------------/
 
   // <pinvk, _, _>
-  // Prepares the invokation of a vector.
+  // Prepares the invocation of a function.
   // Creates a new frame on top of the call stack, and sets its closure context
   // using the context of the object on top of the stack.
   PINVK,
 
   // <invk, _, _>
-  // Invokes the vector of the object on the top of the stack.
+  // Invokes the vector of the object on top of the stack.
   INVK,
 
   // <rtrn, _, _>

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -125,6 +125,16 @@ enum instr_enum : uint32_t
 
   //------------------------- Control instructions ----------------------------/
 
+  // <pinvk, _, _>
+  // Prepares the invokation of a vector.
+  // Creates a new frame on top of the call stack, and sets its closure context
+  // using the context of the object on top of the stack.
+  PINVK,
+
+  // <invk, _, _>
+  // Invokes the vector of the object on the top of the stack.
+  INVK,
+
   // <rtrn, _, _>
   // Unwinds from the current call frame and jumps to the previous one.
   RTRN,
@@ -763,6 +773,20 @@ public:
 
 
 //----------------------- Control instructions --------------------------------/
+
+
+class instr_handler_pinvk : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+
+class instr_handler_invk : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
 
 
 class instr_handler_rtrn : public instr_handler

--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -131,10 +131,10 @@ public:
   void erase_ntvhndl(corevm::dyobj::ntvhndl_key&)
     throw(corevm::runtime::native_type_handle_deletion_error);
 
+  const corevm::runtime::instr_addr pc() const;
+
   void set_pc(const corevm::runtime::instr_addr)
     throw(corevm::runtime::invalid_instr_addr_error);
-
-  void append_instrs(const std::vector<corevm::runtime::instr>&);
 
   void append_vector(const corevm::runtime::vector&);
 
@@ -179,8 +179,7 @@ private:
   bool m_pause_exec;
   uint8_t m_gc_flag;
   corevm::runtime::instr_addr m_pc;
-  std::vector<corevm::runtime::instr> m_instrs;
-  std::vector<corevm::runtime::vector> m_vectors;
+  corevm::runtime::vector m_instrs;
   corevm::dyobj::dynamic_object_heap<garbage_collection_scheme::dynamic_object_manager> m_dynamic_object_heap;
   std::stack<corevm::dyobj::dyobj_id> m_dyobj_stack;
   std::list<corevm::runtime::frame> m_call_stack;

--- a/src/runtime/frame.cc
+++ b/src/runtime/frame.cc
@@ -30,7 +30,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 corevm::runtime::frame::frame(corevm::runtime::closure_ctx closure_ctx):
   m_closure_ctx(closure_ctx),
-  m_start_addr(corevm::runtime::NONESET_INSTR_ADDR),
   m_return_addr(corevm::runtime::NONESET_INSTR_ADDR),
   m_visible_vars(std::unordered_map<corevm::runtime::variable_key, corevm::dyobj::dyobj_id>()),
   m_invisible_vars(std::unordered_map<corevm::runtime::variable_key, corevm::dyobj::dyobj_id>()),
@@ -55,13 +54,7 @@ corevm::runtime::frame::eval_stack_size() const
 corevm::runtime::instr_addr
 corevm::runtime::frame::get_start_addr() const
 {
-  return m_start_addr;
-}
-
-void
-corevm::runtime::frame::set_start_addr(const corevm::runtime::instr_addr start_addr)
-{
-  m_start_addr = start_addr;
+  return m_return_addr + 1;
 }
 
 corevm::runtime::instr_addr

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -672,12 +672,12 @@ corevm::runtime::instr_handler_pinvk::execute(
 
   if (ctx.compartment_id == corevm::runtime::NONESET_COMPARTMENT_ID)
   {
-    throw corevm::runtime::compartment_not_found_error();
+    throw corevm::runtime::compartment_not_found_error(ctx.compartment_id);
   }
 
   if (ctx.closure_id == corevm::runtime::NONESET_CLOSURE_ID)
   {
-    throw corevm::runtime::closure_not_found_error();
+    throw corevm::runtime::closure_not_found_error(ctx.closure_id);
   }
 
   corevm::runtime::frame frame(ctx);
@@ -690,10 +690,9 @@ corevm::runtime::instr_handler_invk::execute(
 {
   corevm::runtime::frame& frame = process.top_frame();
 
-  frame.set_start_addr(process.pc() + 1);
   frame.set_return_addr(process.pc());
 
-  corevm::runtime::closure_ctx = frame.closure_ctx();
+  corevm::runtime::closure_ctx ctx = frame.closure_ctx();
 
   corevm::runtime::compartment* compartment = nullptr;
   process.get_compartment(ctx.compartment_id, &compartment);

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -670,6 +670,16 @@ corevm::runtime::instr_handler_pinvk::execute(
   corevm::runtime::closure_ctx ctx;
   obj.closure_ctx(&ctx);
 
+  if (ctx.compartment_id == corevm::runtime::NONESET_COMPARTMENT_ID)
+  {
+    throw corevm::runtime::compartment_not_found_error();
+  }
+
+  if (ctx.closure_id == corevm::runtime::NONESET_CLOSURE_ID)
+  {
+    throw corevm::runtime::closure_not_found_error();
+  }
+
   corevm::runtime::frame frame(ctx);
   process.push_frame(frame);
 }
@@ -680,13 +690,10 @@ corevm::runtime::instr_handler_invk::execute(
 {
   corevm::runtime::frame& frame = process.top_frame();
 
+  frame.set_start_addr(process.pc() + 1);
   frame.set_return_addr(process.pc());
 
-  corevm::dyobj::dyobj_id id = process.top_stack();
-  auto& obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
-
-  corevm::runtime::closure_ctx ctx;
-  obj.closure_ctx(&ctx);
+  corevm::runtime::closure_ctx = frame.closure_ctx();
 
   corevm::runtime::compartment* compartment = nullptr;
   process.get_compartment(ctx.compartment_id, &compartment);

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -378,6 +378,12 @@ corevm::runtime::process::maybe_gc()
   );
 
   this->resume_exec();
+};
+
+const corevm::runtime::instr_addr
+corevm::runtime::process::pc() const
+{
+  return m_pc;
 }
 
 void
@@ -391,29 +397,13 @@ corevm::runtime::process::set_pc(const corevm::runtime::instr_addr addr)
 
   m_pc = addr;
 
-  while (this->has_frame())
-  {
-    corevm::runtime::frame& frame = this->top_frame();
-
-    if (! (frame.get_start_addr() > addr) )
-    {
-      break;
-    }
-
-    this->pop_frame();
-  }
-}
-
-void
-corevm::runtime::process::append_instrs(const std::vector<corevm::runtime::instr>& instrs)
-{
-  m_instrs.insert(m_instrs.end(), instrs.begin(), instrs.end());
+  m_instrs.erase(m_instrs.begin() + pc(), m_instrs.end());
 }
 
 void
 corevm::runtime::process::append_vector(const corevm::runtime::vector& vector)
 {
-  m_vectors.push_back(vector);
+  m_instrs.insert(m_instrs.end(), vector.begin(), vector.end());
 }
 
 void

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -780,7 +780,7 @@ TEST_F(process_control_instrs_test, TestInstrPINVK)
   ASSERT_TRUE(m_ctx == ctx);
 }
 
-TEST_F(process_obj_instrs_test, TestInstrINVK)
+TEST_F(process_control_instrs_test, TestInstrINVK)
 {
   corevm::runtime::closure_id closure_id = 1;
   corevm::runtime::compartment_id compartment_id = 0;
@@ -791,9 +791,14 @@ TEST_F(process_obj_instrs_test, TestInstrINVK)
   corevm::runtime::frame frame(m_ctx);
   m_process.push_frame(frame);
 
-  corevm::runtime::closure closure;
+  corevm::runtime::vector vector;
+  corevm::runtime::closure closure {
+    .id = closure_id,
+    .parent_id = corevm::runtime::NONESET_CLOSURE_ID,
+    .vector = vector
+  };
   corevm::runtime::compartment compartment;
-  corevm::runtime::closure_table {
+  corevm::runtime::closure_table closure_table {
     { closure_id, closure }
   };
 
@@ -806,7 +811,7 @@ TEST_F(process_obj_instrs_test, TestInstrINVK)
     .oprd2=0
   };
 
-  m_process.set_pc(10);
+  m_process.set_pc(8);
 
   corevm::runtime::instr_handler_invk handler;
   handler.execute(instr, m_process);

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -733,7 +733,7 @@ public:
 protected:
   virtual void SetUp()
   {
-    std::vector<corevm::runtime::instr> instrs = {
+    corevm::runtime::vector vector {
       corevm::runtime::instr(),
       corevm::runtime::instr(),
       corevm::runtime::instr(),
@@ -745,7 +745,7 @@ protected:
       corevm::runtime::instr(),
       corevm::runtime::instr(),
     };
-    m_process.append_instrs(instrs);
+    m_process.append_vector(vector);
   }
 
   corevm::runtime::process m_process;


### PR DESCRIPTION
Implement the `invk` function to invoke function calls.

The `invk` instruction works by getting the closure context associated with the object on top of the stack, loads its vector into the process, and proceeds to process execution.

One issue with this is that because the `putarg` and `putkwarg` instructions will need to insert function arguments into the next frame, the frame needs to be created based on the object's closure context first. Therefore, `invk` along cannot achieve this behavior because we cannot call it either before or after these two instructions.

Therefore, the instruction `pinvk` is implemented to achieve this behavior. `pinvk` stands for "prepare invoke", and what it does is that it creates the top frame using the right closure context first. After this gets called, `putarg` and `putkwargs` can be used to load arguments from the stack onto the next frame, should there be any arguments to be loaded. Finally, `invk` is called to actually run the vector.