### PR TITLE
[COREVM-131] Implement .at() method for object_container

### DIFF
--- a/include/dyobj/dynamic_object_heap.h
+++ b/include/dyobj/dynamic_object_heap.h
@@ -228,11 +228,9 @@ corevm::dyobj::dynamic_object_heap<dynamic_object_manager>::at(
   void* raw_ptr = corevm::dyobj::obj_id_to_ptr(id);
   dynamic_object_type* ptr = static_cast<dynamic_object_type*>(raw_ptr);
 
-  try
-  {
-    ptr = m_container[ptr];
-  }
-  catch(const corevm::memory::invalid_address_error&)
+  ptr = m_container[ptr];
+
+  if (ptr == nullptr)
   {
     throw corevm::dyobj::object_not_found_error(id);
   }

--- a/src/runtime/native_types_pool.cc
+++ b/src/runtime/native_types_pool.cc
@@ -53,11 +53,9 @@ corevm::runtime::native_types_pool::at(const corevm::dyobj::ntvhndl_key& key)
   void* raw_ptr = corevm::runtime::ntvhndl_key_to_ptr(key);
   _MyType::pointer ptr = static_cast<_MyType::pointer>(raw_ptr);
 
-  try
-  {
-    ptr = m_container[ptr];
-  }
-  catch(const corevm::memory::invalid_address_error&)
+  ptr = m_container[ptr];
+
+  if (ptr == nullptr)
   {
     throw corevm::runtime::native_type_handle_not_found_error();
   }
@@ -91,14 +89,14 @@ corevm::runtime::native_types_pool::erase(const corevm::dyobj::ntvhndl_key& key)
   void* raw_ptr = corevm::runtime::ntvhndl_key_to_ptr(key);
   _MyType::pointer ptr = static_cast<_MyType::pointer>(raw_ptr);
 
-  try
-  {
-    m_container.destroy(ptr);
-  }
-  catch(const corevm::memory::invalid_address_error&)
+  ptr = m_container[ptr];
+
+  if (ptr == nullptr)
   {
     throw corevm::runtime::native_type_handle_not_found_error();
   }
+
+  m_container.destroy(ptr);
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/memory/object_container_unittest.cc
+++ b/tests/memory/object_container_unittest.cc
@@ -62,11 +62,17 @@ TEST_F(object_container_unittest, TestCreateAndUpdate)
 
   ASSERT_EQ(data, t->data);
 
+  t = m_container.at(p);
+
+  ASSERT_EQ(data, t->data);
+
   m_container.destroy(p);
+
+  ASSERT_EQ(nullptr, m_container[p]);
 
   ASSERT_THROW(
     {
-      m_container[p];
+      m_container.at(p);
     },
     corevm::memory::invalid_address_error
   );


### PR DESCRIPTION
Implement a `.at()` method for `corevm::memory::object_container` that throws `invalid_address_error` on invalid errors, and make the `[]` operator returns `nullptr` on invalid errors. This reduces the cost of catching `invalid_address_error` at the higher levels.