### PR TITLE
[COREVM-132] Associate compartments with file paths

### DIFF
--- a/include/frontend/bytecode_loader.h
+++ b/include/frontend/bytecode_loader.h
@@ -44,7 +44,9 @@ using sneaker::json::JSON;
 class bytecode_loader
 {
 public:
-  virtual void load(const JSON&, corevm::runtime::process&) = 0;
+  virtual void load(
+    const std::string&, const JSON&, corevm::runtime::process&) = 0;
+
   virtual const std::string format() const = 0;
   virtual const std::string version() const = 0;
   virtual const std::string schema() const = 0;
@@ -53,7 +55,8 @@ public:
     throw(corevm::frontend::file_loading_error);
 
 private:
-  static void validate_and_load(const JSON&, corevm::runtime::process&);
+  static void validate_and_load(
+    const std::string&, const JSON&, corevm::runtime::process&);
 };
 
 // -----------------------------------------------------------------------------

--- a/include/frontend/bytecode_loader_v0_1.h
+++ b/include/frontend/bytecode_loader_v0_1.h
@@ -45,7 +45,7 @@ using sneaker::json::JSON;
 class bytecode_loader_v0_1 : public corevm::frontend::bytecode_loader
 {
 public:
-  virtual void load(const JSON&, corevm::runtime::process&);
+  virtual void load(const std::string&, const JSON&, corevm::runtime::process&);
   virtual const std::string format() const;
   virtual const std::string version() const;
   virtual const std::string schema() const;

--- a/include/runtime/compartment.h
+++ b/include/runtime/compartment.h
@@ -27,6 +27,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "common.h"
 #include "errors.h"
 
+#include <string>
+
 
 namespace corevm {
 
@@ -37,9 +39,9 @@ namespace runtime {
 class compartment
 {
 public:
-  explicit compartment();
+  explicit compartment(const std::string&);
 
-  const corevm::runtime::compartment_id id() const;
+  const std::string& path() const;
 
   void set_encoding_map(const corevm::runtime::encoding_map&);
 
@@ -54,7 +56,7 @@ public:
   void set_closure_table(const corevm::runtime::closure_table&);
 
 private:
-  corevm::runtime::compartment_id m_id;
+  const std::string m_path;
   corevm::runtime::encoding_map m_encoding_map;
   corevm::runtime::closure_table m_closure_table;
 };

--- a/src/frontend/bytecode_loader.cc
+++ b/src/frontend/bytecode_loader.cc
@@ -146,7 +146,7 @@ corevm::frontend::internal::schema_repository::load_by_format_and_version(
 
 void
 corevm::frontend::bytecode_loader::validate_and_load(
-  const JSON& content_json, corevm::runtime::process& process)
+  const std::string& path, const JSON& content_json, corevm::runtime::process& process)
 {
   const JSON::object& json_object = content_json.object_items();
 
@@ -190,7 +190,7 @@ corevm::frontend::bytecode_loader::validate_and_load(
   }
 
   // Load
-  loader->load(content_json, process);
+  loader->load(path, content_json, process);
 }
 
 // -----------------------------------------------------------------------------
@@ -237,7 +237,7 @@ corevm::frontend::bytecode_loader::load(
     );
   }
 
-  bytecode_loader::validate_and_load(content_json, process);
+  bytecode_loader::validate_and_load(path, content_json, process);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/frontend/bytecode_loader_v0_1.cc
+++ b/src/frontend/bytecode_loader_v0_1.cc
@@ -168,9 +168,9 @@ corevm::frontend::bytecode_loader_v0_1::schema() const
 
 void
 corevm::frontend::bytecode_loader_v0_1::load(
-  const JSON& content_json, corevm::runtime::process& process)
+  const std::string& path, const JSON& content_json, corevm::runtime::process& process)
 {
-  corevm::runtime::compartment compartment;
+  corevm::runtime::compartment compartment(path);
 
   const JSON::object& json_object = content_json.object_items();
 

--- a/src/runtime/compartment.cc
+++ b/src/runtime/compartment.cc
@@ -23,16 +23,20 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../../include/runtime/compartment.h"
 
 
-corevm::runtime::compartment::compartment()
+// -----------------------------------------------------------------------------
+
+corevm::runtime::compartment::compartment(const std::string& path)
+  :
+  m_path(path)
 {
 }
 
 // -----------------------------------------------------------------------------
 
-const corevm::runtime::compartment_id
-corevm::runtime::compartment::id() const
+const std::string&
+corevm::runtime::compartment::path() const
 {
-  return m_id;
+  return m_path;
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -42,6 +42,9 @@ using corevm::runtime::process;
 
 class instrs_unittest : public ::testing::Test
 {
+public:
+  static const std::string DUMMY_PATH;
+
 protected:
   corevm::runtime::closure_ctx m_ctx {
     .compartment_id = corevm::runtime::NONESET_COMPARTMENT_ID,
@@ -51,9 +54,14 @@ protected:
 
 // -----------------------------------------------------------------------------
 
+const std::string instrs_unittest::DUMMY_PATH = "./my/path/file";
+
+// -----------------------------------------------------------------------------
+
 class instrs_obj_unittest : public instrs_unittest
 {
 protected:
+
   virtual void SetUp()
   {
     m_process.push_frame(*m_frame);
@@ -90,7 +98,7 @@ TEST_F(instrs_obj_unittest, TestInstrLDOBJ)
   corevm::runtime::compartment_id compartment_id = 0;
   corevm::runtime::closure_id closure_id = 10;
   corevm::runtime::closure_id parent_closure_id = 100;
-  corevm::runtime::compartment compartment;
+  corevm::runtime::compartment compartment(DUMMY_PATH);
   corevm::runtime::vector vector;
 
   corevm::runtime::closure_ctx ctx1 {
@@ -272,7 +280,7 @@ TEST_F(instrs_obj_unittest, TestInstrLDOBJ2)
   corevm::runtime::compartment_id compartment_id = 0;
   corevm::runtime::closure_id closure_id = 10;
   corevm::runtime::closure_id parent_closure_id = 100;
-  corevm::runtime::compartment compartment;
+  corevm::runtime::compartment compartment(DUMMY_PATH);
   corevm::runtime::vector vector;
 
   corevm::runtime::closure_ctx ctx1 {
@@ -851,7 +859,7 @@ TEST_F(instrs_control_instrs_test, TestInstrINVK)
     .parent_id = corevm::runtime::NONESET_CLOSURE_ID,
     .vector = vector
   };
-  corevm::runtime::compartment compartment;
+  corevm::runtime::compartment compartment(DUMMY_PATH);
   corevm::runtime::closure_table closure_table {
     { closure_id, closure }
   };


### PR DESCRIPTION
Compartments should be associated with their corresponding file paths so that when loading modules, they can be inspected and looked up by a file path from the process.

At the same time, IDs associated with compartments can be removed, since they are stored in closure contexts, and can be looked up using that within a process.