### PR TITLE
[COREVM-133] Load starting closure into process when running

### DIFF
--- a/include/runtime/closure.h
+++ b/include/runtime/closure.h
@@ -25,7 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "common.h"
 #include "vector.h"
-#include <unordered_map>
+#include <vector>
 
 
 namespace corevm {
@@ -36,14 +36,14 @@ namespace runtime {
 
 typedef struct closure
 {
-  const corevm::runtime::closure_id id;
-  const corevm::runtime::closure_id parent_id;
-  const corevm::runtime::vector vector;
+  corevm::runtime::closure_id id;
+  corevm::runtime::closure_id parent_id;
+  corevm::runtime::vector vector;
 } closure;
 
 // -----------------------------------------------------------------------------
 
-typedef std::unordered_map<corevm::runtime::closure_id, corevm::runtime::closure> closure_table;
+typedef std::vector<corevm::runtime::closure> closure_table;
 
 // -----------------------------------------------------------------------------
 

--- a/include/runtime/compartment.h
+++ b/include/runtime/compartment.h
@@ -50,10 +50,12 @@ public:
 
   size_t closure_count() const;
 
-  const corevm::runtime::closure& get_closure_by_id(
+  const corevm::runtime::closure get_closure_by_id(
     corevm::runtime::closure_id) const throw(corevm::runtime::closure_not_found_error);
 
   void set_closure_table(const corevm::runtime::closure_table&);
+
+  bool get_starting_closure(corevm::runtime::closure*);
 
 private:
   const std::string m_path;

--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -177,6 +177,8 @@ public:
   void get_compartment(corevm::runtime::compartment_id, corevm::runtime::compartment**);
 
 private:
+  bool pre_start();
+
   bool should_gc();
 
   void insert_vector(corevm::runtime::vector& vector);

--- a/src/frontend/bytecode_loader_v0_1.cc
+++ b/src/frontend/bytecode_loader_v0_1.cc
@@ -240,17 +240,15 @@ corevm::frontend::bytecode_loader_v0_1::load(
     corevm::runtime::closure_id id = str_to_closure_id_map.at(name);
     corevm::runtime::closure_id parent_id = str_to_closure_id_map.at(parent);
 
-    closure_table.emplace(
-      std::make_pair(
-        id,
-        corevm::runtime::closure {
-          .id = id,
-          .parent_id = parent_id,
-          .vector = vector
-        }
-      )
+    closure_table.push_back(
+      corevm::runtime::closure {
+        .id = id,
+        .parent_id = parent_id,
+        .vector = vector
+      }
     );
-  }
+
+  } /* end for-loop */
 
   compartment.set_closure_table(closure_table);
 

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -384,9 +384,36 @@ corevm::runtime::process::can_execute()
 
 // -----------------------------------------------------------------------------
 
+bool
+corevm::runtime::process::pre_start()
+{
+  corevm::runtime::closure closure;
+
+  if (m_compartments.empty())
+  {
+    return false;
+  }
+
+  bool res = m_compartments.front().get_starting_closure(&closure);
+
+  if (res)
+  {
+    insert_vector(closure.vector);
+  }
+
+  return res;
+}
+
+// -----------------------------------------------------------------------------
+
 void
 corevm::runtime::process::start()
 {
+  if (!pre_start())
+  {
+    return;
+  }
+
   while (can_execute())
   {
     while (m_pause_exec) {}

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -124,13 +124,12 @@ TEST_F(instrs_obj_unittest, TestInstrLDOBJ)
   };
 
   corevm::runtime::closure_table closure_table {
-    { closure_id, closure },
-    { parent_closure_id, parent_closure }
+    closure,
+    parent_closure
   };
 
   corevm::runtime::frame frame(ctx1);
   corevm::runtime::frame parent_frame(ctx2);
-
   compartment.set_closure_table(closure_table);
 
   m_process.insert_compartment(compartment);
@@ -306,8 +305,8 @@ TEST_F(instrs_obj_unittest, TestInstrLDOBJ2)
   };
 
   corevm::runtime::closure_table closure_table {
-    { closure_id, closure },
-    { parent_closure_id, parent_closure }
+    closure,
+    parent_closure
   };
 
   corevm::runtime::frame frame(ctx1);
@@ -861,7 +860,7 @@ TEST_F(instrs_control_instrs_test, TestInstrINVK)
   };
   corevm::runtime::compartment compartment(DUMMY_PATH);
   corevm::runtime::closure_table closure_table {
-    { closure_id, closure }
+    closure
   };
 
   compartment.set_closure_table(closure_table);


### PR DESCRIPTION
Make processes be able to load the starting closure when running.

The mechanism works by adding a method `get_starting_closure(closure*)` to `corevm::runtime::compartment`, which loads the starting closure within that compartment. A starting closure is defined as one with a valid `.id` and a `.parent_closure_id` that does NOT equal to `NONESET_CLOSURE_ID`.

I also made the underlying type of a `closure_table` from `std::unordered_map` to `std::vector`. This way we don't have to store the IDs redundantly, and also the difference of performance of linear lookup is negligible vs. the approach using unordered_map since the number of closures within a compartment is not expected to be a large number.

One caveat that I encountered during this change is that the original signature of `corevm::runtime::compartment::get_closure_by_id` actually causes `std::bad_alloc` after changing to the new approach of storing closures. The reason is because the method was returning references of the closure found, but in reality, the list of closures within the compartment can change, so the reference may not be valid through its lifespan. The fix is simply return a copy of the closure instead of a reference. 