### PR TITLE
[COREVM-138] Add assertion on deallocation result

### DIFF
--- a/include/memory/allocation_policy.h
+++ b/include/memory/allocation_policy.h
@@ -30,8 +30,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <cassert>
 #include <cstdint>
 
-#include <sys/types.h>
-
 
 namespace corevm {
 
@@ -127,8 +125,7 @@ corevm::memory::allocation_policy<T, AllocationScheme, N>::deallocate(
   typename allocation_policy<T, AllocationScheme, N>::size_type
 )
 {
-  ssize_t res = m_allocator.deallocate(p);
-
+  int res = m_allocator.deallocate(p);
   assert(res == 1);
 }
 

--- a/include/memory/allocation_policy.h
+++ b/include/memory/allocation_policy.h
@@ -27,7 +27,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <sneaker/allocator/alloc_policy.h>
 
+#include <cassert>
 #include <cstdint>
+
+#include <sys/types.h>
 
 
 namespace corevm {
@@ -124,7 +127,9 @@ corevm::memory::allocation_policy<T, AllocationScheme, N>::deallocate(
   typename allocation_policy<T, AllocationScheme, N>::size_type
 )
 {
-  m_allocator.deallocate(p);
+  ssize_t res = m_allocator.deallocate(p);
+
+  assert(res == 1);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Currently, `corevm::memory::allocator`'s `int deallocate(void*) noexcept` returns a value of `1` if the deallocation is successful, and a value of `-1` otherwise. I'm adding an assertion at places where this gets called to make sure the deallocation is successful.