### PR TITLE
[COREVM-139] Make instruction printings print all two operands

### DIFF
--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -1912,7 +1912,7 @@ public:
   using map_type = typename std::unordered_map<
     corevm::runtime::instr_code, corevm::runtime::instr_info>;
 
-  static std::string instr_to_string(const corevm::runtime::instr&);
+  static const std::string instr_to_string(const corevm::runtime::instr&);
 
   static corevm::runtime::instr_info find(corevm::runtime::instr_code instr_code)
     throw(corevm::runtime::invalid_instr_error);

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -219,19 +219,10 @@ corevm::runtime::instr_handler_meta::validate_instr(
 
 // -----------------------------------------------------------------------------
 
-std::string
+const std::string
 corevm::runtime::instr_handler_meta::instr_to_string(const corevm::runtime::instr& instr)
 {
-  corevm::runtime::instr_info instr_info = corevm::runtime::instr_handler_meta::validate_instr(instr);
-
-  if (instr_info.num_oprd == 1)
-  {
-    return str(boost::format("<%d %d __>") % instr.code % instr.oprd1);
-  }
-  else
-  {
-    return str(boost::format("<%d %d %d>") % instr.code % instr.oprd1 % instr.oprd2);
-  }
+  return str(boost::format("<%lu %llu %llu>") % instr.code % instr.oprd1 % instr.oprd2);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Currently, instructions converted to strings are based on the number of operands they have. This patch makes them print all 2 operands.