### PR TITLE
[COREVM-144] Dynamic object flags cleanup

### DIFF
--- a/include/dyobj/dynamic_object.h
+++ b/include/dyobj/dynamic_object.h
@@ -325,7 +325,7 @@ bool
 corevm::dyobj::dynamic_object<dynamic_object_manager>::is_garbage_collectible() const noexcept
 {
   return (
-    get_flag(corevm::dyobj::flags::IS_NOT_GARBAGE_COLLECTIBLE) == false &&
+    get_flag(corevm::dyobj::flags::DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE) == false &&
     m_manager.garbage_collectible()
   );
 }

--- a/include/dyobj/flags.h
+++ b/include/dyobj/flags.h
@@ -48,8 +48,6 @@ enum flags : uint32_t
 
   /* ------------- Bits that pertain to the scope of objects ---------------- */
 
-  DYOBJ_IS_GLOBAL_OBJ,
-
   DYOBJ_IS_INVISIBLE_TO_USER,
 
   /* ------- Bits that pertain to the various attributes of objects --------- */

--- a/include/dyobj/flags.h
+++ b/include/dyobj/flags.h
@@ -54,7 +54,7 @@ enum flags : uint32_t
 
   /* ------- Bits that pertain to the various attributes of objects --------- */
 
-  DYOBJ_IS_CALLABLE,
+  DYOBJ_IS_NON_CALLABLE,
 
   DYOBJ_IS_IMMUTABLE,
 

--- a/include/dyobj/flags.h
+++ b/include/dyobj/flags.h
@@ -33,42 +33,34 @@ namespace dyobj {
 
 
 /**
- * Dynamic object flags are represented by 8 bits unsigned integers.
+ * Dynamic object flags are represented by 32-bit unsigned integers.
  * These flag bits are defined so that the default value of 0 would be the
  * appropriate value for most objects.
  */
-enum flags : uint8_t
+enum flags : uint32_t
 {
 
   /* ------------ Bits that pertain to the lifespan of objects -------------- */
 
-  IS_NOT_GARBAGE_COLLECTIBLE = 1,
+  DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE = 1,
 
-  IS_WEAK_REF = 2,
-
-  IS_INDELIBLE = 3,
+  DYOBJ_IS_INDELIBLE,
 
   /* ------------- Bits that pertain to the scope of objects ---------------- */
 
-  IS_GLOBAL_OBJ = 4,
+  DYOBJ_IS_GLOBAL_OBJ,
 
-  IS_SUPPLIED_OBJ = 5,
-
-  IS_INVISIBLE_TO_USER = 6,
+  DYOBJ_IS_INVISIBLE_TO_USER,
 
   /* ------- Bits that pertain to the various attributes of objects --------- */
 
-  IS_CALLABLE = 7,
+  DYOBJ_IS_CALLABLE,
 
-  IS_IMMUTABLE = 8,
+  DYOBJ_IS_IMMUTABLE,
 
   /* ------------------------ Max value allowed ----------------------------- */
 
-  MAX_VALUE = 9,
-
-  /* ---------- THE REMAINING BITS ARE RESERVED FOR FURTHER USE ------------- */
-
-  LAST_PLACEHOLDER = 32,
+  DYOBJ_MAX_VALUE = 32,
 
 };
 

--- a/include/runtime/errors.h
+++ b/include/runtime/errors.h
@@ -164,7 +164,21 @@ public:
       )
     )
   {
+  }
+};
 
+// -----------------------------------------------------------------------------
+
+class invocation_error : public corevm::runtime::runtime_error
+{
+public:
+  explicit invocation_error(const corevm::dyobj::dyobj_id id):
+    corevm::runtime::runtime_error(
+      str(
+        format("Cannot invoke call on object %s") % corevm::dyobj::id_to_string(id)
+      )
+    )
+  {
   }
 };
 

--- a/include/runtime/errors.h
+++ b/include/runtime/errors.h
@@ -25,6 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "common.h"
 #include "../errors.h"
+#include "../dyobj/dyobj_id.h"
 
 #include <boost/format.hpp>
 
@@ -148,6 +149,22 @@ public:
   explicit native_type_handle_deletion_error():
     corevm::runtime::runtime_error("Native type handle cannot be deleted")
   {
+  }
+};
+
+// -----------------------------------------------------------------------------
+
+class object_deletion_error : public corevm::runtime::runtime_error
+{
+public:
+  explicit object_deletion_error(const corevm::dyobj::dyobj_id id):
+    corevm::runtime::runtime_error(
+      str(
+        format("Cannot delete object %s") % corevm::dyobj::id_to_string(id)
+      )
+    )
+  {
+
   }
 };
 

--- a/src/dyobj/flags.cc
+++ b/src/dyobj/flags.cc
@@ -26,5 +26,5 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 bool
 corevm::dyobj::is_valid_flag_bit(char bit)
 {
-  return (0 < bit) && (bit < corevm::dyobj::flags::MAX_VALUE);
+  return (0 < bit) && (bit < corevm::dyobj::flags::DYOBJ_MAX_VALUE);
 }

--- a/src/gc/reference_count_garbage_collection_scheme.cc
+++ b/src/gc/reference_count_garbage_collection_scheme.cc
@@ -189,7 +189,7 @@ public:
 
   void operator()(dyobj_id_type id, dynamic_object_type& object)
   {
-    if (object.get_flag(corevm::dyobj::flags::IS_NOT_GARBAGE_COLLECTIBLE) == true)
+    if (object.get_flag(corevm::dyobj::flags::DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE))
     {
       object.iterate(
         [&](

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -478,7 +478,7 @@ corevm::runtime::instr_handler_setattr::execute(
 
   auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(target_id);
 
-  if (obj.get_flag(corevm::dyobj::flags::IS_IMMUTABLE))
+  if (obj.get_flag(corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE))
   {
     throw corevm::runtime::invalid_operation_error(
       str(format("cannot mutate immutable object 0x%08x") % target_id)
@@ -503,7 +503,7 @@ corevm::runtime::instr_handler_delattr::execute(
   corevm::dyobj::dyobj_id id = process.pop_stack();
   auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
 
-  if (obj.get_flag(corevm::dyobj::flags::IS_IMMUTABLE))
+  if (obj.get_flag(corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE))
   {
     throw corevm::runtime::invalid_operation_error(
       str(format("cannot mutate immutable object 0x%08x") % id)
@@ -527,7 +527,7 @@ corevm::runtime::instr_handler_mute::execute(
   corevm::dyobj::dyobj_id id = process.top_stack();
   auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
 
-  obj.clear_flag(corevm::dyobj::flags::IS_IMMUTABLE);
+  obj.clear_flag(corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE);
 }
 
 // -----------------------------------------------------------------------------
@@ -539,7 +539,7 @@ corevm::runtime::instr_handler_unmute::execute(
   corevm::dyobj::dyobj_id id = process.top_stack();
   auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
 
-  obj.set_flag(corevm::dyobj::flags::IS_IMMUTABLE);
+  obj.set_flag(corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -626,6 +626,12 @@ corevm::runtime::instr_handler_delobj::execute(
 
   corevm::dyobj::dyobj_id id = frame.pop_visible_var(key);
   auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
+
+  if (obj.get_flag(corevm::dyobj::flags::DYOBJ_IS_INDELIBLE))
+  {
+    throw corevm::runtime::object_deletion_error(id);
+  }
+
   obj.manager().on_delete();
 }
 
@@ -640,6 +646,12 @@ corevm::runtime::instr_handler_delobj2::execute(
 
   corevm::dyobj::dyobj_id id = frame.pop_invisible_var(key);
   auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
+
+  if (obj.get_flag(corevm::dyobj::flags::DYOBJ_IS_INDELIBLE))
+  {
+    throw corevm::runtime::object_deletion_error(id);
+  }
+
   obj.manager().on_delete();
 }
 

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -775,6 +775,11 @@ corevm::runtime::instr_handler_pinvk::execute(
   corevm::dyobj::dyobj_id id = process.top_stack();
   auto& obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
 
+  if (obj.get_flag(corevm::dyobj::flags::DYOBJ_IS_NON_CALLABLE))
+  {
+    throw corevm::runtime::invocation_error(id);
+  }
+
   corevm::runtime::closure_ctx ctx;
   obj.closure_ctx(&ctx);
 

--- a/tests/dyobj/dynamic_object_unittest.cc
+++ b/tests/dyobj/dynamic_object_unittest.cc
@@ -58,8 +58,8 @@ TEST_F(dynamic_object_unittest, TestGetAndSetFlags)
 
   ASSERT_EQ(0, obj.flags());
 
-  char flag1 = corevm::dyobj::flags::IS_NOT_GARBAGE_COLLECTIBLE;
-  char flag2 = corevm::dyobj::flags::IS_IMMUTABLE;
+  char flag1 = corevm::dyobj::flags::DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE;
+  char flag2 = corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE;
 
   ASSERT_FALSE(obj.get_flag(flag1));
   ASSERT_FALSE(obj.get_flag(flag2));
@@ -76,7 +76,7 @@ TEST_F(dynamic_object_unittest, TestGetAndSetFlags)
   ASSERT_FALSE(obj.get_flag(flag1));
   ASSERT_FALSE(obj.get_flag(flag2));
 
-  char invalid_flag = corevm::dyobj::flags::MAX_VALUE;
+  char invalid_flag = corevm::dyobj::flags::DYOBJ_MAX_VALUE;
 
   ASSERT_THROW(
     {

--- a/tests/gc/garbage_collection_unittest.cc
+++ b/tests/gc/garbage_collection_unittest.cc
@@ -74,7 +74,7 @@ protected:
   void help_set_as_non_garbage_collectible(corevm::dyobj::dyobj_id id)
   {
     auto& obj = m_heap.at(id);
-    obj.set_flag(corevm::dyobj::flags::IS_NOT_GARBAGE_COLLECTIBLE);
+    obj.set_flag(corevm::dyobj::flags::DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE);
   }
 
   corevm::dyobj::dynamic_object_heap<

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -272,7 +272,7 @@ TEST_F(instrs_obj_unittest, TestInstrMUTE)
 
   auto &actual_obj = process::adapter(m_process).help_get_dyobj(actual_id);
 
-  ASSERT_EQ(false, actual_obj.get_flag(corevm::dyobj::IS_IMMUTABLE));
+  ASSERT_EQ(false, actual_obj.get_flag(corevm::dyobj::DYOBJ_IS_IMMUTABLE));
 }
 
 // -----------------------------------------------------------------------------
@@ -292,7 +292,7 @@ TEST_F(instrs_obj_unittest, TestInstrUNMUTE)
 
   auto &actual_obj = process::adapter(m_process).help_get_dyobj(actual_id);
 
-  ASSERT_EQ(true, actual_obj.get_flag(corevm::dyobj::IS_IMMUTABLE));
+  ASSERT_EQ(true, actual_obj.get_flag(corevm::dyobj::DYOBJ_IS_IMMUTABLE));
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Clean up the dynamic object flags set, with the following goals:

* Add the `DYOBJ_` prefix to all the flag values.
* Remove the `IS_WEAK_REF` flag.
* Remove the `IS_SUPPLIED_OBJ` flag.
* Remove the `IS_GLOBAL_OBJ` flag.
* Support the `IS_INDELIBLE` value.
* Rename `IS_CALLABLE` to `IS_NON_CALLABLE` and add support for it.