### PR TITLE
[COREVM-145] Test allocation over max size

### DIFF
--- a/include/dyobj/dynamic_object_heap.h
+++ b/include/dyobj/dynamic_object_heap.h
@@ -169,12 +169,12 @@ template<class dynamic_object_manager>
 void
 corevm::dyobj::dynamic_object_heap<dynamic_object_manager>::erase(dynamic_object_id_type id)
 {
-  auto itr = m_container.find(id);
+  void* raw_ptr = corevm::dyobj::obj_id_to_ptr(id);
+  dynamic_object_type* ptr = static_cast<dynamic_object_type*>(raw_ptr);
 
-  if (itr != m_container.end())
-  {
-    erase(itr);
-  }
+  ptr = m_container.at(ptr);
+
+  m_container.destroy(ptr);
 }
 
 // -----------------------------------------------------------------------------

--- a/include/memory/allocation_policy.h
+++ b/include/memory/allocation_policy.h
@@ -59,7 +59,15 @@ public:
 
   inline uint64_t base_addr() const;
 
+  /**
+   * The maximum number of bytes can be used.
+   */
   inline uint64_t total_size() const;
+
+  /**
+   * The maximum number of elements can be allocated.
+   */
+  inline uint64_t max_size() const;
 
 protected:
   corevm::memory::allocator<N, AllocationScheme> m_allocator;
@@ -145,6 +153,15 @@ uint64_t
 corevm::memory::allocation_policy<T, AllocationScheme, N>::total_size() const
 {
   return m_allocator.total_size();
+}
+
+// -----------------------------------------------------------------------------
+
+template<typename T, typename AllocationScheme, size_t N>
+uint64_t
+corevm::memory::allocation_policy<T, AllocationScheme, N>::max_size() const
+{
+  return total_size() / sizeof(T);
 }
 
 // -----------------------------------------------------------------------------

--- a/include/memory/object_container.h
+++ b/include/memory/object_container.h
@@ -312,7 +312,7 @@ template<typename T, typename AllocatorType>
 typename corevm::memory::object_container<T, AllocatorType>::size_type
 corevm::memory::object_container<T, AllocatorType>::max_size() const
 {
-  return m_addrs.max_size();
+  return m_allocator.max_size();
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/dyobj/dynamic_object_heap_unittest.cc
+++ b/tests/dyobj/dynamic_object_heap_unittest.cc
@@ -27,6 +27,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <sneaker/testing/_unittest.h>
 
+#include <vector>
+
 
 class dummy_dynamic_object_manager {};
 
@@ -57,6 +59,10 @@ TEST_F(dynamic_object_heap_unittest, TestCreateDyobj)
 
   ASSERT_EQ(id1, obj1.id());
   ASSERT_EQ(id2, obj2.id());
+
+  // Clean up.
+  m_heap.erase(id1);
+  m_heap.erase(id2);
 }
 
 // -----------------------------------------------------------------------------
@@ -68,6 +74,39 @@ TEST_F(dynamic_object_heap_unittest, TestAtOnNonExistentKeys)
 
   ASSERT_THROW(m_heap.at(id1), corevm::dyobj::object_not_found_error);
   ASSERT_THROW(m_heap.at(id2), corevm::dyobj::object_not_found_error);
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(dynamic_object_heap_unittest, TestAllocationOverMaxSize)
+{
+  auto max_size = 1024;
+
+  // TODO: [COREVM-146] Make dynamic object heap take max size as parameter
+  // auto max_size = m_heap.max_size();
+
+  std::vector<corevm::dyobj::dyobj_id> ids(max_size);
+
+  for (auto i = 0; i < max_size; ++i)
+  {
+    ids[i] = m_heap.create_dyobj();
+  }
+
+  // TODO: [COREVM-146] Make dynamic object heap take max size as parameter
+  /*
+  ASSERT_THROW(
+    {
+      m_heap.create_dyobj();
+    },
+    corevm::dyobj::object_heap_insertion_failed_error
+  );
+  */
+
+  // Clean up.
+  for (auto i = 0; i < ids.size(); ++i)
+  {
+    m_heap.erase(ids[i]);
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/memory/allocation_policy_unittest.cc
+++ b/tests/memory/allocation_policy_unittest.cc
@@ -58,10 +58,42 @@ TEST_F(allocation_policy_unit_test, TestAllocateAndDeallocate)
   int *nums = allocation_policy.allocate(N);
   assert(nums);
 
-  for (int i = 0; i < N; ++i) nums[i] = i;
-  for (int i = 0; i < N; ++i) ASSERT_EQ(i, nums[i]);
+  for (int i = 0; i < N; ++i)
+  {
+    nums[i] = i;
+  }
+
+  for (int i = 0; i < N; ++i)
+  {
+    ASSERT_EQ(i, nums[i]);
+  }
 
   allocation_policy.deallocate(nums, N);
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(allocation_policy_unit_test, TestAllocationOverMaxSize)
+{
+  _AllocPolicyType allocation_policy;
+  uint64_t max_size = allocation_policy.max_size();
+
+  std::vector<int*> ptrs(max_size);
+
+  for (auto i = 0; i < max_size; ++i)
+  {
+    int* ptr = allocation_policy.allocate(1);
+    ASSERT_NE(nullptr, ptr);
+    ptrs[i] = ptr;
+  }
+
+  ASSERT_EQ(nullptr, allocation_policy.allocate(1));
+
+  // Clean up.
+  for (auto i = 0; i < max_size; ++i)
+  {
+    allocation_policy.deallocate(ptrs[i], sizeof(int));
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/memory/object_container_unittest.cc
+++ b/tests/memory/object_container_unittest.cc
@@ -20,9 +20,12 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
+#include "../../include/memory/allocation_policy.h"
+#include "../../include/memory/sequential_allocation_scheme.h"
 #include "../../include/memory/errors.h"
 #include "../../include/memory/object_container.h"
 
+#include <sneaker/allocator/allocator.h>
 #include <sneaker/testing/_unittest.h>
 
 #include <algorithm>
@@ -31,20 +34,32 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 class object_container_unittest : public ::testing::Test
 {
-public:
-  typedef struct dummy
+protected:
+  typedef struct Dummy
   {
     int data;
   } T;
 
-protected:
+  /**
+   * `std::allocator` cannot be used here for this unit test, as much as it is
+   * desired for the sake of unit testing. The reason is that
+   * `std::allocator::max_size()` returns the max size of an individual element,
+   * where as the meaning of `max_size()` in coreVM is defined as returning the
+   * maximum number of elements can be allocated by an allocator.
+   */
+  template<typename T, typename AllocationScheme, size_t N>
+  class Allocator : public sneaker::allocator::allocator<T, corevm::memory::allocation_policy<T, AllocationScheme, N>>
+  {
+  };
+
   virtual void TearDown()
   {
     // Make sure test cases clean up the container properly.
     ASSERT_EQ(m_container.end(), m_container.begin());
   }
 
-  corevm::memory::object_container<dummy> m_container;
+  typedef Allocator<Dummy, corevm::memory::first_fit_allocation_scheme, 1024> MyAllocator;
+  corevm::memory::object_container<Dummy, MyAllocator> m_container;
 };
 
 // -----------------------------------------------------------------------------
@@ -336,7 +351,7 @@ TEST_F(object_container_unittest, TestIteratorReflectsChange2)
 
   m_container.destroy(p2);
 
-  ASSERT_EQ(m_container.begin(), ++itr);
+  ASSERT_EQ(m_container.begin(), itr);
 
   m_container.destroy(p);
 }
@@ -393,6 +408,32 @@ TEST_F(object_container_unittest, TestErase)
   m_container.erase(itr);
 
   ASSERT_EQ(0, m_container.size());
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(object_container_unittest, TestAllocationOverMaxSize)
+{
+  uint64_t max_size = m_container.max_size();
+
+  std::vector<T*> ptrs(max_size);
+
+  for (auto i = 0; i < max_size; ++i)
+  {
+      T* ptr = m_container.create();
+      ASSERT_NE(nullptr, ptr);
+      ptrs[i] = ptr;
+  }
+
+  T* ptr = m_container.create();
+  ASSERT_EQ(nullptr, ptr);
+
+  // Clean up.
+  for (auto i = 0; i < ptrs.size(); ++i)
+  {
+    T* ptr = ptrs[i];
+    m_container.destroy(ptr);
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/memory/object_container_unittest.cc
+++ b/tests/memory/object_container_unittest.cc
@@ -420,9 +420,9 @@ TEST_F(object_container_unittest, TestAllocationOverMaxSize)
 
   for (auto i = 0; i < max_size; ++i)
   {
-      T* ptr = m_container.create();
-      ASSERT_NE(nullptr, ptr);
-      ptrs[i] = ptr;
+    T* ptr = m_container.create();
+    ASSERT_NE(nullptr, ptr);
+    ptrs[i] = ptr;
   }
 
   T* ptr = m_container.create();


### PR DESCRIPTION
There is the need to add tests for allocations over the max size allowed/specified. This can be done together for the memory alllocator, object container, as well as for the dynamic object heap at the high level. 

To do this, the first step is to expose the correct `.max_size()` in `object_container`.