### PR TITLE
[COREVM-148] Code cleanup

### DIFF
--- a/include/dyobj/dynamic_object_heap.h
+++ b/include/dyobj/dynamic_object_heap.h
@@ -101,7 +101,7 @@ public:
     throw(corevm::dyobj::object_not_found_error);
 
   dynamic_object_id_type create_dyobj()
-    throw(corevm::dyobj::object_heap_insertion_failed_error);
+    throw(corevm::dyobj::object_creation_error);
 
 private:
   dynamic_object_container_type m_container;
@@ -270,13 +270,13 @@ corevm::dyobj::dynamic_object_heap<dynamic_object_manager>::at(
 template<class dynamic_object_manager>
 typename corevm::dyobj::dynamic_object_heap<dynamic_object_manager>::dynamic_object_id_type
 corevm::dyobj::dynamic_object_heap<dynamic_object_manager>::create_dyobj()
-  throw(corevm::dyobj::object_heap_insertion_failed_error)
+  throw(corevm::dyobj::object_creation_error)
 {
   auto obj_ptr = m_container.create();
 
   if (obj_ptr == nullptr)
   {
-    throw corevm::dyobj::object_heap_insertion_failed_error();
+    throw corevm::dyobj::object_creation_error();
   }
 
   auto id = corevm::dyobj::obj_ptr_to_id(obj_ptr);

--- a/include/dyobj/errors.h
+++ b/include/dyobj/errors.h
@@ -144,17 +144,6 @@ public:
 
 // -----------------------------------------------------------------------------
 
-class object_id_exceed_limit_error : public corevm::dyobj::runtime_error
-{
-public:
-  explicit object_id_exceed_limit_error():
-    corevm::dyobj::runtime_error("The maximum limit of dynamic object ID has been exceeded")
-  {
-  }
-};
-
-// -----------------------------------------------------------------------------
-
 class object_creation_error : public corevm::dyobj::runtime_error
 {
 public:

--- a/include/dyobj/errors.h
+++ b/include/dyobj/errors.h
@@ -155,11 +155,11 @@ public:
 
 // -----------------------------------------------------------------------------
 
-class object_heap_insertion_failed_error : public corevm::dyobj::runtime_error
+class object_creation_error : public corevm::dyobj::runtime_error
 {
 public:
-  explicit object_heap_insertion_failed_error():
-    corevm::dyobj::runtime_error("Dynamic object has failed to be inserted into the heap")
+  explicit object_creation_error():
+    corevm::dyobj::runtime_error("Failed to create dynamic object")
   {
   }
 };

--- a/include/types/native_array.h
+++ b/include/types/native_array.h
@@ -45,136 +45,57 @@ using native_array_base = typename std::vector<element_type>;
 class native_array : public native_array_base
 {
 public:
-  explicit native_array() : native_array_base() {}
+  native_array();
 
-  native_array(const native_array_base& x) : native_array_base(x) {}
-  native_array(native_array_base&& x) : native_array_base(x) {}
+  native_array(const native_array_base&);
 
-  native_array(std::initializer_list<value_type> il) : native_array_base(il) {}
+  native_array(native_array_base&&);
 
-  native_array(int8_t)
-  {
-    throw corevm::types::conversion_error("int8", "array");
-  }
+  native_array(std::initializer_list<value_type>);
 
-  operator int8_t() const
-  {
-    throw corevm::types::conversion_error("array", "int8");
-  }
+  native_array(int8_t);
 
-  native_array& operator+() const
-  {
-    throw corevm::types::invalid_operator_error("+", "array");
-  }
+  operator int8_t() const;
 
-  native_array& operator-() const
-  {
-    throw corevm::types::invalid_operator_error("-", "array");
-  }
+  native_array& operator+() const;
 
-  native_array& operator++() const
-  {
-    throw corevm::types::invalid_operator_error("++", "array");
-  }
+  native_array& operator-() const;
 
-  native_array& operator--() const
-  {
-    throw corevm::types::invalid_operator_error("--", "array");
-  }
+  native_array& operator++() const;
 
-  native_array& operator!() const
-  {
-    throw corevm::types::invalid_operator_error("!", "array");
-  }
+  native_array& operator--() const;
 
-  native_array& operator~() const
-  {
-    throw corevm::types::invalid_operator_error("~", "array");
-  }
+  native_array& operator!() const;
 
-  native_array& operator+(const native_array&) const
-  {
-    throw corevm::types::invalid_operator_error("+", "array");
-  }
+  native_array& operator~() const;
 
-  native_array& operator-(const native_array&) const
-  {
-    throw corevm::types::invalid_operator_error("-", "array");
-  }
+  native_array& operator+(const native_array&) const;
 
-  native_array& operator*(const native_array&) const
-  {
-    throw corevm::types::invalid_operator_error("*", "array");
-  }
+  native_array& operator-(const native_array&) const;
 
-  native_array& operator/(const native_array&) const
-  {
-    throw corevm::types::invalid_operator_error("/", "array");
-  }
+  native_array& operator*(const native_array&) const;
 
-  native_array& operator%(const native_array&) const
-  {
-    throw corevm::types::invalid_operator_error("%", "array");
-  }
+  native_array& operator/(const native_array&) const;
 
-  native_array& operator&&(const native_array&) const
-  {
-    throw corevm::types::invalid_operator_error("&&", "array");
-  }
+  native_array& operator%(const native_array&) const;
 
-  native_array& operator||(const native_array&) const
-  {
-    throw corevm::types::invalid_operator_error("||", "array");
-  }
+  native_array& operator&&(const native_array&) const;
 
-  native_array& operator&(const native_array&) const
-  {
-    throw corevm::types::invalid_operator_error("&", "array");
-  }
+  native_array& operator||(const native_array&) const;
 
-  native_array& operator|(const native_array&) const
-  {
-    throw corevm::types::invalid_operator_error("|", "array");
-  }
+  native_array& operator&(const native_array&) const;
 
-  native_array& operator^(const native_array&) const
-  {
-    throw corevm::types::invalid_operator_error("^", "array");
-  }
+  native_array& operator|(const native_array&) const;
 
-  native_array& operator<<(const native_array&) const
-  {
-    throw corevm::types::invalid_operator_error("<<", "array");
-  }
+  native_array& operator^(const native_array&) const;
 
-  native_array& operator>>(const native_array&) const
-  {
-    throw corevm::types::invalid_operator_error(">>", "array");
-  }
+  native_array& operator<<(const native_array&) const;
 
-  reference at(size_type n) throw(corevm::types::out_of_range_error)
-  {
-    try
-    {
-      return native_array_base::at(n);
-    }
-    catch (const std::out_of_range&)
-    {
-      throw corevm::types::out_of_range_error("Array index out of range");
-    }
-  }
+  native_array& operator>>(const native_array&) const;
 
-  const_reference at(size_type n) const throw(corevm::types::out_of_range_error)
-  {
-    try
-    {
-      return native_array_base::at(n);
-    }
-    catch (const std::out_of_range&)
-    {
-      throw corevm::types::out_of_range_error("Array index out of range");
-    }
-  }
+  reference at(size_type n) throw(corevm::types::out_of_range_error);
+
+  const_reference at(size_type n) const throw(corevm::types::out_of_range_error);
 };
 
 

--- a/include/types/native_map.h
+++ b/include/types/native_map.h
@@ -26,7 +26,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "errors.h"
 
 #include <cstdint>
-#include <stdexcept>
 #include <unordered_map>
 
 
@@ -42,151 +41,67 @@ typedef uint64_t native_map_mapped_type;
 
 using native_map_base = typename std::unordered_map<native_map_key_type, native_map_mapped_type>;
 
-#ifndef DEFAULT_NATIVE_MAP_INITIAL_CAPACITY
-  #define DEFAULT_NATIVE_MAP_INITIAL_CAPACITY 10
-#endif
 
 class native_map : public native_map_base
 {
 public:
-  explicit native_map() : native_map_base(DEFAULT_NATIVE_MAP_INITIAL_CAPACITY) {}
+  native_map();
 
-  native_map(const native_map_base& x) : native_map_base(x) {}
-  native_map(native_map_base&& x) : native_map_base(x) {}
+  native_map(const native_map_base&);
 
-  native_map(std::initializer_list<value_type> il) : native_map_base(il) {}
+  native_map(native_map_base&&);
 
-  native_map(int8_t)
-  {
-    throw corevm::types::conversion_error("int8", "map");
-  }
+  native_map(std::initializer_list<value_type>);
 
-  operator int8_t() const
-  {
-    throw corevm::types::conversion_error("map", "int8");
-  }
+  native_map(int8_t);
 
-  native_map& operator+() const
-  {
-    throw corevm::types::invalid_operator_error("+", "map");
-  }
+  operator int8_t() const;
 
-  native_map& operator-() const
-  {
-    throw corevm::types::invalid_operator_error("-", "map");
-  }
+  native_map& operator+() const;
 
-  native_map& operator++() const
-  {
-    throw corevm::types::invalid_operator_error("++", "map");
-  }
+  native_map& operator-() const;
 
-  native_map& operator--() const
-  {
-    throw corevm::types::invalid_operator_error("--", "map");
-  }
+  native_map& operator++() const;
 
-  native_map& operator!() const
-  {
-    throw corevm::types::invalid_operator_error("!", "map");
-  }
+  native_map& operator--() const;
 
-  native_map& operator~() const
-  {
-    throw corevm::types::invalid_operator_error("~", "map");
-  }
+  native_map& operator!() const;
 
-  native_map& operator+(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("+", "map");
-  }
+  native_map& operator~() const;
 
-  native_map& operator-(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("-", "map");
-  }
+  native_map& operator+(const native_map&) const;
 
-  native_map& operator*(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("*", "map");
-  }
+  native_map& operator-(const native_map&) const;
 
-  native_map& operator/(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("/", "map");
-  }
+  native_map& operator*(const native_map&) const;
 
-  native_map& operator%(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("%", "map");
-  }
+  native_map& operator/(const native_map&) const;
 
-  native_map& operator&&(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("&&", "map");
-  }
+  native_map& operator%(const native_map&) const;
 
-  native_map& operator||(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("||", "map");
-  }
+  native_map& operator&&(const native_map&) const;
 
-  native_map& operator&(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("&", "map");
-  }
+  native_map& operator||(const native_map&) const;
 
-  native_map& operator|(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("|", "map");
-  }
+  native_map& operator&(const native_map&) const;
 
-  native_map& operator^(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("^", "map");
-  }
+  native_map& operator|(const native_map&) const;
 
-  native_map& operator<<(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("<<", "map");
-  }
+  native_map& operator^(const native_map&) const;
 
-  native_map& operator>>(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error(">>", "map");
-  }
+  native_map& operator<<(const native_map&) const;
 
-  native_map& operator<(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("<", "map");
-  }
+  native_map& operator>>(const native_map&) const;
 
-  native_map& operator<=(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error("<=", "map");
-  }
+  native_map& operator<(const native_map&) const;
 
-  native_map& operator>(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error(">", "map");
-  }
+  native_map& operator<=(const native_map&) const;
 
-  native_map& operator>=(const native_map&) const
-  {
-    throw corevm::types::invalid_operator_error(">=", "map");
-  }
+  native_map& operator>(const native_map&) const;
 
-  mapped_type& at(const key_type& k) throw(corevm::types::out_of_range_error)
-  {
-    try
-    {
-      return native_map_base::at(k);
-    }
-    catch (const std::out_of_range&)
-    {
-      throw corevm::types::out_of_range_error("Map key out of range");
-    }
-  }
+  native_map& operator>=(const native_map&) const;
+
+  mapped_type& at(const key_type& k) throw(corevm::types::out_of_range_error);
 };
 
 

--- a/include/types/native_string.h
+++ b/include/types/native_string.h
@@ -26,7 +26,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "errors.h"
 
 #include <cstdint>
-#include <stdexcept>
 #include <string>
 
 
@@ -42,195 +41,76 @@ typedef std::string native_string_base;
 class native_string : public native_string_base
 {
 public:
-  explicit native_string(): native_string_base() {}
-  native_string(const char* s): native_string_base(s) {}
-  native_string(const native_string_base& str) : native_string_base(str) {}
+  native_string();
 
-  native_string(native_string_base&& str) : native_string_base(str) {}
+  native_string(const char* s);
 
-  native_string(int8_t) {
-    throw corevm::types::conversion_error("int8", "string");
-  }
+  native_string(const native_string_base& str);
 
-  operator int8_t() const
-  {
-    throw corevm::types::conversion_error("string", "int8");
-  }
+  native_string(native_string_base&& str);
 
-  native_string& operator+() const
-  {
-    throw corevm::types::invalid_operator_error("+", "string");
-  }
+  native_string(int8_t);
 
-  native_string& operator-() const
-  {
-    throw corevm::types::invalid_operator_error("-", "string");
-  }
+  operator int8_t() const;
 
-  native_string& operator++() const
-  {
-    throw corevm::types::invalid_operator_error("++", "string");
-  }
+  native_string& operator+() const;
 
-  native_string& operator--() const
-  {
-    throw corevm::types::invalid_operator_error("--", "string");
-  }
+  native_string& operator-() const;
 
-  native_string& operator!() const
-  {
-    throw corevm::types::invalid_operator_error("!", "string");
-  }
+  native_string& operator++() const;
 
-  native_string& operator~() const
-  {
-    throw corevm::types::invalid_operator_error("~", "string");
-  }
+  native_string& operator--() const;
 
-  native_string& operator+(const native_string&) const
-  {
-    throw corevm::types::invalid_operator_error("+", "string");
-  }
+  native_string& operator!() const;
 
-  native_string& operator-(const native_string&) const
-  {
-    throw corevm::types::invalid_operator_error("-", "string");
-  }
+  native_string& operator~() const;
 
-  native_string& operator*(const native_string&) const
-  {
-    throw corevm::types::invalid_operator_error("*", "string");
-  }
+  native_string& operator+(const native_string&) const;
 
-  native_string& operator/(const native_string&) const
-  {
-    throw corevm::types::invalid_operator_error("/", "string");
-  }
+  native_string& operator-(const native_string&) const;
 
-  native_string& operator%(const native_string&) const
-  {
-    throw corevm::types::invalid_operator_error("%", "string");
-  }
+  native_string& operator*(const native_string&) const;
 
-  native_string& operator&&(const native_string&) const
-  {
-    throw corevm::types::invalid_operator_error("&&", "string");
-  }
+  native_string& operator/(const native_string&) const;
 
-  native_string& operator||(const native_string&) const
-  {
-    throw corevm::types::invalid_operator_error("||", "string");
-  }
+  native_string& operator%(const native_string&) const;
 
-  native_string& operator&(const native_string&) const
-  {
-    throw corevm::types::invalid_operator_error("&", "string");
-  }
+  native_string& operator&&(const native_string&) const;
 
-  native_string& operator|(const native_string&) const
-  {
-    throw corevm::types::invalid_operator_error("|", "string");
-  }
+  native_string& operator||(const native_string&) const;
 
-  native_string& operator^(const native_string&) const
-  {
-    throw corevm::types::invalid_operator_error("^", "string");
-  }
+  native_string& operator&(const native_string&) const;
 
-  native_string& operator<<(const native_string&) const
-  {
-    throw corevm::types::invalid_operator_error("<<", "string");
-  }
+  native_string& operator|(const native_string&) const;
 
-  native_string& operator>>(const native_string&) const
-  {
-    throw corevm::types::invalid_operator_error(">>", "string");
-  }
+  native_string& operator^(const native_string&) const;
 
-  reference at(size_type n) throw(corevm::types::out_of_range_error)
-  {
-    try
-    {
-      return native_string_base::at(n);
-    }
-    catch (const std::out_of_range&)
-    {
-      throw corevm::types::out_of_range_error("String index out of range");
-    }
-  }
+  native_string& operator<<(const native_string&) const;
 
-  const_reference at(size_type n) const throw(corevm::types::out_of_range_error)
-  {
-    try
-    {
-      return native_string_base::at(n);
-    }
-    catch (const std::out_of_range&)
-    {
-      throw corevm::types::out_of_range_error("String index out of range");
-    }
-  }
+  native_string& operator>>(const native_string&) const;
 
-  corevm::types::native_string& insert(size_type pos, const corevm::types::native_string& str) throw(corevm::types::out_of_range_error)
-  {
-    try
-    {
-      return static_cast<corevm::types::native_string&>(native_string_base::insert(pos, str));
-    }
-    catch (const std::out_of_range&)
-    {
-      throw corevm::types::out_of_range_error("String index out of range");
-    }
-  }
+  reference at(size_type n) throw(corevm::types::out_of_range_error);
 
-  corevm::types::native_string& insert(size_type pos, size_type n, value_type c) throw(corevm::types::out_of_range_error)
-  {
-    try
-    {
-      return static_cast<corevm::types::native_string&>(native_string_base::insert(pos, n, c));
-    }
-    catch (const std::out_of_range&)
-    {
-      throw corevm::types::out_of_range_error("String index out of range");
-    }
-  }
+  const_reference at(size_type n) const
+    throw(corevm::types::out_of_range_error);
 
-  corevm::types::native_string& erase(size_type pos) throw(corevm::types::out_of_range_error)
-  {
-    try
-    {
-      return static_cast<corevm::types::native_string&>(native_string_base::erase(pos));
-    }
-    catch (const std::out_of_range&)
-    {
-      throw corevm::types::out_of_range_error("String index out of range");
-    }
-  }
+  corevm::types::native_string& insert(
+    size_type pos, const corevm::types::native_string& str)
+    throw(corevm::types::out_of_range_error);
 
-  corevm::types::native_string& erase(size_type pos, size_type len) throw(corevm::types::out_of_range_error)
-  {
-    try
-    {
-      return static_cast<corevm::types::native_string&>(native_string_base::erase(pos, len));
-    }
-    catch (const std::out_of_range&)
-    {
-      throw corevm::types::out_of_range_error("String index out of range");
-    }
-  }
+  corevm::types::native_string& insert(
+    size_type pos, size_type n, value_type c) throw(corevm::types::out_of_range_error);
+
+  corevm::types::native_string& erase(size_type pos)
+    throw(corevm::types::out_of_range_error);
+
+  corevm::types::native_string& erase(
+    size_type pos, size_type len) throw(corevm::types::out_of_range_error);
 
   corevm::types::native_string& replace(
-    size_type pos, size_type len, const corevm::types::native_string& str) throw(corevm::types::out_of_range_error)
-  {
-    try
-    {
-      return static_cast<corevm::types::native_string&>(native_string_base::replace(pos, len, str));
-    }
-    catch (const std::out_of_range&)
-    {
-      throw corevm::types::out_of_range_error("String index out of range");
-    }
-  }
+    size_type pos,
+    size_type len,
+    const corevm::types::native_string& str) throw(corevm::types::out_of_range_error);
 };
 
 

--- a/src/types/native_array.cc
+++ b/src/types/native_array.cc
@@ -1,0 +1,250 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Yanzheng Li
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+#include "../../include/types/native_array.h"
+
+#include "../../include/types/errors.h"
+
+#include <cstdint>
+#include <stdexcept>
+
+
+corevm::types::native_array::native_array()
+  :
+  native_array_base()
+{
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array::native_array(const native_array_base& other)
+  :
+  native_array_base(other)
+{
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array::native_array(native_array_base&& other)
+  :
+  native_array_base(other)
+{
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array::native_array(std::initializer_list<value_type> il)
+  :
+  native_array_base(il)
+{
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array::native_array(int8_t)
+{
+  throw corevm::types::conversion_error("int8", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array::operator int8_t() const
+{
+  throw corevm::types::conversion_error("array", "int8");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator+() const
+{
+  throw corevm::types::invalid_operator_error("+", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator-() const
+{
+  throw corevm::types::invalid_operator_error("-", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator++() const
+{
+  throw corevm::types::invalid_operator_error("++", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator--() const
+{
+  throw corevm::types::invalid_operator_error("--", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator!() const
+{
+  throw corevm::types::invalid_operator_error("!", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator~() const
+{
+  throw corevm::types::invalid_operator_error("~", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator+(const native_array&) const
+{
+  throw corevm::types::invalid_operator_error("+", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator-(const native_array&) const
+{
+  throw corevm::types::invalid_operator_error("-", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator*(const native_array&) const
+{
+  throw corevm::types::invalid_operator_error("*", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator/(const native_array&) const
+{
+  throw corevm::types::invalid_operator_error("/", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator%(const native_array&) const
+{
+  throw corevm::types::invalid_operator_error("%", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator&&(const native_array&) const
+{
+  throw corevm::types::invalid_operator_error("&&", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator||(const native_array&) const
+{
+  throw corevm::types::invalid_operator_error("||", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator&(const native_array&) const
+{
+  throw corevm::types::invalid_operator_error("&", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator|(const native_array&) const
+{
+  throw corevm::types::invalid_operator_error("|", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator^(const native_array&) const
+{
+  throw corevm::types::invalid_operator_error("^", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator<<(const native_array&) const
+{
+  throw corevm::types::invalid_operator_error("<<", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array&
+corevm::types::native_array::operator>>(const native_array&) const
+{
+  throw corevm::types::invalid_operator_error(">>", "array");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array::reference
+corevm::types::native_array::at(size_type n) throw(corevm::types::out_of_range_error)
+{
+  try
+  {
+    return native_array_base::at(n);
+  }
+  catch (const std::out_of_range&)
+  {
+    throw corevm::types::out_of_range_error("Array index out of range");
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_array::const_reference
+corevm::types::native_array::at(size_type n) const
+  throw(corevm::types::out_of_range_error)
+{
+  try
+  {
+    return native_array_base::at(n);
+  }
+  catch (const std::out_of_range&)
+  {
+    throw corevm::types::out_of_range_error("Array index out of range");
+  }
+}
+
+// -----------------------------------------------------------------------------

--- a/src/types/native_map.cc
+++ b/src/types/native_map.cc
@@ -1,0 +1,270 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Yanzheng Li
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+#include "../../include/types/native_map.h"
+
+#include "../../include/types/errors.h"
+
+#include <cstdint>
+#include <stdexcept>
+
+
+const size_t DEFAULT_NATIVE_MAP_INITIAL_CAPACITY = 10;
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map::native_map()
+  :
+  native_map_base(DEFAULT_NATIVE_MAP_INITIAL_CAPACITY)
+{
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map::native_map(const native_map_base& other)
+  :
+  native_map_base(other)
+{
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map::native_map(native_map_base&& other)
+  :
+  native_map_base(other)
+{
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map::native_map(std::initializer_list<value_type> il)
+  :
+  native_map_base(il)
+{
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map::native_map(int8_t)
+{
+  throw corevm::types::conversion_error("int8", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map::operator int8_t() const
+{
+  throw corevm::types::conversion_error("map", "int8");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator+() const
+{
+  throw corevm::types::invalid_operator_error("+", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator-() const
+{
+  throw corevm::types::invalid_operator_error("-", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator++() const
+{
+  throw corevm::types::invalid_operator_error("++", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator--() const
+{
+  throw corevm::types::invalid_operator_error("--", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator!() const
+{
+  throw corevm::types::invalid_operator_error("!", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator~() const
+{
+  throw corevm::types::invalid_operator_error("~", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator+(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("+", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator-(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("-", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator*(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("*", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator/(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("/", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator%(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("%", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator&&(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("&&", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator||(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("||", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator&(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("&", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator|(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("|", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator^(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("^", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator<<(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("<<", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator>>(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error(">>", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator<(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("<", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator<=(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error("<=", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator>(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error(">", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map&
+corevm::types::native_map::operator>=(const native_map&) const
+{
+  throw corevm::types::invalid_operator_error(">=", "map");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_map::mapped_type&
+corevm::types::native_map::at(const key_type& k) throw(corevm::types::out_of_range_error)
+{
+  try
+  {
+    return native_map_base::at(k);
+  }
+  catch (const std::out_of_range&)
+  {
+    throw corevm::types::out_of_range_error("Map key out of range");
+  }
+}
+
+// -----------------------------------------------------------------------------

--- a/src/types/native_string.cc
+++ b/src/types/native_string.cc
@@ -1,0 +1,329 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Yanzheng Li
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+#include "../../include/types/native_string.h"
+
+#include "../../include/types/errors.h"
+
+#include <cstdint>
+#include <stdexcept>
+
+
+corevm::types::native_string::native_string()
+  :
+  native_string_base()
+{
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string::native_string(const char* s)
+  :
+  native_string_base(s)
+{
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string::native_string(const native_string_base& str)
+  :
+  native_string_base(str)
+{
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string::native_string(native_string_base&& str)
+  :
+  native_string_base(str)
+{
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string::native_string(int8_t)
+{
+  throw corevm::types::conversion_error("int8", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string::operator int8_t() const
+{
+  throw corevm::types::conversion_error("string", "int8");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator+() const
+{
+  throw corevm::types::invalid_operator_error("+", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator-() const
+{
+  throw corevm::types::invalid_operator_error("-", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator++() const
+{
+  throw corevm::types::invalid_operator_error("++", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator--() const
+{
+  throw corevm::types::invalid_operator_error("--", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator!() const
+{
+  throw corevm::types::invalid_operator_error("!", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator~() const
+{
+  throw corevm::types::invalid_operator_error("~", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator+(const native_string&) const
+{
+  throw corevm::types::invalid_operator_error("+", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator-(const native_string&) const
+{
+  throw corevm::types::invalid_operator_error("-", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator*(const native_string&) const
+{
+  throw corevm::types::invalid_operator_error("*", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator/(const native_string&) const
+{
+  throw corevm::types::invalid_operator_error("/", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator%(const native_string&) const
+{
+  throw corevm::types::invalid_operator_error("%", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator&&(const native_string&) const
+{
+  throw corevm::types::invalid_operator_error("&&", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator||(const native_string&) const
+{
+  throw corevm::types::invalid_operator_error("||", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator&(const native_string&) const
+{
+  throw corevm::types::invalid_operator_error("&", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator|(const native_string&) const
+{
+  throw corevm::types::invalid_operator_error("|", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator^(const native_string&) const
+{
+  throw corevm::types::invalid_operator_error("^", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator<<(const native_string&) const
+{
+  throw corevm::types::invalid_operator_error("<<", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::operator>>(const native_string&) const
+{
+  throw corevm::types::invalid_operator_error(">>", "string");
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string::reference
+corevm::types::native_string::at(size_type n) throw(corevm::types::out_of_range_error)
+{
+  try
+  {
+    return native_string_base::at(n);
+  }
+  catch (const std::out_of_range&)
+  {
+    throw corevm::types::out_of_range_error("String index out of range");
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string::const_reference
+corevm::types::native_string::at(size_type n) const throw(corevm::types::out_of_range_error)
+{
+  try
+  {
+    return native_string_base::at(n);
+  }
+  catch (const std::out_of_range&)
+  {
+    throw corevm::types::out_of_range_error("String index out of range");
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::insert(
+  size_type pos, const corevm::types::native_string& str) throw(corevm::types::out_of_range_error)
+{
+  try
+  {
+    return static_cast<corevm::types::native_string&>(native_string_base::insert(pos, str));
+  }
+  catch (const std::out_of_range&)
+  {
+    throw corevm::types::out_of_range_error("String index out of range");
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::insert(size_type pos, size_type n, value_type c)
+  throw(corevm::types::out_of_range_error)
+{
+  try
+  {
+    return static_cast<corevm::types::native_string&>(native_string_base::insert(pos, n, c));
+  }
+  catch (const std::out_of_range&)
+  {
+    throw corevm::types::out_of_range_error("String index out of range");
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::erase(size_type pos)
+  throw(corevm::types::out_of_range_error)
+{
+  try
+  {
+    return static_cast<corevm::types::native_string&>(native_string_base::erase(pos));
+  }
+  catch (const std::out_of_range&)
+  {
+    throw corevm::types::out_of_range_error("String index out of range");
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::erase(size_type pos, size_type len)
+  throw(corevm::types::out_of_range_error)
+{
+  try
+  {
+    return static_cast<corevm::types::native_string&>(native_string_base::erase(pos, len));
+  }
+  catch (const std::out_of_range&)
+  {
+    throw corevm::types::out_of_range_error("String index out of range");
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::types::native_string&
+corevm::types::native_string::replace(size_type pos, size_type len,
+  const corevm::types::native_string& str) throw(corevm::types::out_of_range_error)
+{
+  try
+  {
+    return static_cast<corevm::types::native_string&>(native_string_base::replace(pos, len, str));
+  }
+  catch (const std::out_of_range&)
+  {
+    throw corevm::types::out_of_range_error("String index out of range");
+  }
+}
+
+// -----------------------------------------------------------------------------

--- a/tests/dyobj/dynamic_object_heap_unittest.cc
+++ b/tests/dyobj/dynamic_object_heap_unittest.cc
@@ -101,7 +101,7 @@ TEST_F(dynamic_object_heap_unittest, TestAllocationOverMaxSize)
     {
       m_heap.create_dyobj();
     },
-    corevm::dyobj::object_heap_insertion_failed_error
+    corevm::dyobj::object_creation_error
   );
 
   // Clean up.


### PR DESCRIPTION
* Moved definitions for `native_string`, `native_array`, and `native_map` to source files.
* Renamed `object_heap_insertion_failed_error` to `object_creation_error`.