### PR TITLE
[COREVM-149] Code cleanup

### DIFF
--- a/include/gc/garbage_collection_scheme.h
+++ b/include/gc/garbage_collection_scheme.h
@@ -23,10 +23,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef COREVM_GARBAGE_COLLECTION_SCHEME_H_
 #define COREVM_GARBAGE_COLLECTION_SCHEME_H_
 
-#include "../dyobj/dynamic_object.h"
-#include "../dyobj/dynamic_object_heap.h"
-#include "../dyobj/dynamic_object_manager.h"
-
 #include <cstdint>
 
 
@@ -37,81 +33,6 @@ namespace gc {
 
 
 class garbage_collection_scheme {};
-
-// -----------------------------------------------------------------------------
-
-class mark_and_sweep_garbage_collection_scheme : public garbage_collection_scheme
-{
-public:
-  typedef class dynamic_object_manager : public corevm::dyobj::dynamic_object_manager
-  {
-    public:
-      dynamic_object_manager()
-        :
-        m_marked(false)
-      {
-      }
-
-      virtual inline bool garbage_collectible() const noexcept
-      {
-        return marked();
-      }
-
-      virtual inline void on_create() noexcept
-      {
-        // Do nothing here.
-      }
-
-      virtual inline void on_setattr() noexcept
-      {
-        // Do nothing here.
-      }
-
-      virtual inline void on_delattr() noexcept
-      {
-        // Do nothing here.
-      }
-
-      virtual inline void on_delete() noexcept
-      {
-        // Do nothing here.
-      }
-
-      virtual inline void on_exit() noexcept
-      {
-        // Do nothing here.
-      }
-
-      virtual inline bool marked() const noexcept
-      {
-        return m_marked;
-      }
-
-      virtual inline void mark() noexcept
-      {
-        m_marked = true;
-      }
-
-      virtual inline void unmark() noexcept
-      {
-        m_marked = false;
-      }
-
-    protected:
-      bool m_marked;
-  } mark_and_sweep_dynamic_object_manager;
-
-  using dynamic_object_type = typename corevm::dyobj::dynamic_object<mark_and_sweep_dynamic_object_manager>;
-  using dynamic_object_heap_type = typename corevm::dyobj::dynamic_object_heap<mark_and_sweep_dynamic_object_manager>;
-
-  virtual void gc(dynamic_object_heap_type&) const;
-
-protected:
-  virtual bool is_root_object(const dynamic_object_type&) const noexcept;
-  virtual void mark(dynamic_object_heap_type&, dynamic_object_type&) const;
-};
-
-// -----------------------------------------------------------------------------
 
 
 } /* end namespace gc */

--- a/include/gc/garbage_collection_scheme.h
+++ b/include/gc/garbage_collection_scheme.h
@@ -109,6 +109,34 @@ public:
 
   virtual void gc(dynamic_object_heap_type&) const;
 
+  template<typename dynamic_object_heap_type>
+  class ref_count_heap_iterator
+  {
+  public:
+    explicit ref_count_heap_iterator(
+      dynamic_object_heap_type& heap,
+      const corevm::gc::reference_count_garbage_collection_scheme& scheme)
+      :
+      m_heap(heap),
+      m_scheme(scheme)
+    {
+    }
+
+    void operator()(
+      typename dynamic_object_heap_type::dynamic_object_id_type id,
+      typename dynamic_object_heap_type::dynamic_object_type& object)
+    {
+      m_scheme.check_and_dec_ref_count(m_heap, object);
+      m_scheme.resolve_self_reference_cycles(m_heap, object);
+    }
+
+  private:
+    dynamic_object_heap_type& m_heap;
+    const corevm::gc::reference_count_garbage_collection_scheme& m_scheme;
+  };
+
+  friend class ref_count_heap_iterator<dynamic_object_heap_type>;
+
 protected:
   void check_and_dec_ref_count(dynamic_object_heap_type&, dynamic_object_type&) const;
 

--- a/include/gc/mark_and_sweep_garbage_collection_scheme.h
+++ b/include/gc/mark_and_sweep_garbage_collection_scheme.h
@@ -1,0 +1,119 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Yanzheng Li
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+#ifndef COREVM_MARK_AND_SWEEP_GARBAGE_COLLECTION_SCHEME_H_
+#define COREVM_MARK_AND_SWEEP_GARBAGE_COLLECTION_SCHEME_H_
+
+#include "garbage_collection_scheme.h"
+
+#include "../dyobj/dynamic_object.h"
+#include "../dyobj/dynamic_object_heap.h"
+#include "../dyobj/dynamic_object_manager.h"
+
+#include <cstdint>
+
+
+namespace corevm {
+
+
+namespace gc {
+
+
+class mark_and_sweep_garbage_collection_scheme : public garbage_collection_scheme
+{
+public:
+  typedef class dynamic_object_manager : public corevm::dyobj::dynamic_object_manager
+  {
+    public:
+      dynamic_object_manager()
+        :
+        m_marked(false)
+      {
+      }
+
+      virtual inline bool garbage_collectible() const noexcept
+      {
+        return marked();
+      }
+
+      virtual inline void on_create() noexcept
+      {
+        // Do nothing here.
+      }
+
+      virtual inline void on_setattr() noexcept
+      {
+        // Do nothing here.
+      }
+
+      virtual inline void on_delattr() noexcept
+      {
+        // Do nothing here.
+      }
+
+      virtual inline void on_delete() noexcept
+      {
+        // Do nothing here.
+      }
+
+      virtual inline void on_exit() noexcept
+      {
+        // Do nothing here.
+      }
+
+      virtual inline bool marked() const noexcept
+      {
+        return m_marked;
+      }
+
+      virtual inline void mark() noexcept
+      {
+        m_marked = true;
+      }
+
+      virtual inline void unmark() noexcept
+      {
+        m_marked = false;
+      }
+
+    protected:
+      bool m_marked;
+  } mark_and_sweep_dynamic_object_manager;
+
+  using dynamic_object_type = typename corevm::dyobj::dynamic_object<mark_and_sweep_dynamic_object_manager>;
+  using dynamic_object_heap_type = typename corevm::dyobj::dynamic_object_heap<mark_and_sweep_dynamic_object_manager>;
+
+  virtual void gc(dynamic_object_heap_type&) const;
+
+protected:
+  virtual bool is_root_object(const dynamic_object_type&) const noexcept;
+  virtual void mark(dynamic_object_heap_type&, dynamic_object_type&) const;
+};
+
+
+} /* end namespace gc */
+
+
+} /* end namespace corevm */
+
+
+#endif /* COREVM_MARK_AND_SWEEP_GARBAGE_COLLECTION_SCHEME_H_ */

--- a/include/gc/reference_count_garbage_collection_scheme.h
+++ b/include/gc/reference_count_garbage_collection_scheme.h
@@ -110,27 +110,27 @@ public:
   template<typename dynamic_object_heap_type>
   class heap_iterator
   {
-  public:
-    explicit heap_iterator(
-      dynamic_object_heap_type& heap,
-      const corevm::gc::reference_count_garbage_collection_scheme& scheme)
-      :
-      m_heap(heap),
-      m_scheme(scheme)
-    {
-    }
+    public:
+      explicit heap_iterator(
+        dynamic_object_heap_type& heap,
+        const corevm::gc::reference_count_garbage_collection_scheme& scheme)
+        :
+        m_heap(heap),
+        m_scheme(scheme)
+      {
+      }
 
-    void operator()(
-      typename dynamic_object_heap_type::dynamic_object_id_type id,
-      typename dynamic_object_heap_type::dynamic_object_type& object)
-    {
-      m_scheme.check_and_dec_ref_count(m_heap, object);
-      m_scheme.resolve_self_reference_cycles(m_heap, object);
-    }
+      void operator()(
+        typename dynamic_object_heap_type::dynamic_object_id_type id,
+        typename dynamic_object_heap_type::dynamic_object_type& object)
+      {
+        m_scheme.check_and_dec_ref_count(m_heap, object);
+        m_scheme.resolve_self_reference_cycles(m_heap, object);
+      }
 
-  private:
-    dynamic_object_heap_type& m_heap;
-    const corevm::gc::reference_count_garbage_collection_scheme& m_scheme;
+    private:
+      dynamic_object_heap_type& m_heap;
+      const corevm::gc::reference_count_garbage_collection_scheme& m_scheme;
   };
 
   friend class heap_iterator<dynamic_object_heap_type>;

--- a/include/gc/reference_count_garbage_collection_scheme.h
+++ b/include/gc/reference_count_garbage_collection_scheme.h
@@ -108,10 +108,10 @@ public:
   virtual void gc(dynamic_object_heap_type&) const;
 
   template<typename dynamic_object_heap_type>
-  class ref_count_heap_iterator
+  class heap_iterator
   {
   public:
-    explicit ref_count_heap_iterator(
+    explicit heap_iterator(
       dynamic_object_heap_type& heap,
       const corevm::gc::reference_count_garbage_collection_scheme& scheme)
       :
@@ -133,7 +133,7 @@ public:
     const corevm::gc::reference_count_garbage_collection_scheme& m_scheme;
   };
 
-  friend class ref_count_heap_iterator<dynamic_object_heap_type>;
+  friend class heap_iterator<dynamic_object_heap_type>;
 
 protected:
   void check_and_dec_ref_count(dynamic_object_heap_type&, dynamic_object_type&) const;

--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -36,7 +36,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../../include/dyobj/common.h"
 #include "../../include/dyobj/dynamic_object_heap.h"
 #include "../../include/gc/garbage_collector.h"
-#include "../../include/gc/garbage_collection_scheme.h"
+#include "../../include/gc/reference_count_garbage_collection_scheme.h"
 
 #include <climits>
 #include <cstdint>

--- a/src/gc/mark_and_sweep_garbage_collection_scheme.cc
+++ b/src/gc/mark_and_sweep_garbage_collection_scheme.cc
@@ -20,7 +20,7 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include "../../include/gc/garbage_collection_scheme.h"
+#include "../../include/gc/mark_and_sweep_garbage_collection_scheme.h"
 
 #include <algorithm>
 

--- a/src/gc/reference_count_garbage_collection_scheme.cc
+++ b/src/gc/reference_count_garbage_collection_scheme.cc
@@ -40,7 +40,10 @@ corevm::gc::reference_count_garbage_collection_scheme::gc(
   using _dynamic_object_heap_type = typename
     corevm::gc::reference_count_garbage_collection_scheme::dynamic_object_heap_type;
 
-  ref_count_heap_iterator<_dynamic_object_heap_type> heap_iterator(heap, *this);
+  using heap_iterator_type = typename \
+    corevm::gc::reference_count_garbage_collection_scheme::heap_iterator<_dynamic_object_heap_type>;
+
+  heap_iterator_type heap_iterator(heap, *this);
 
   _dynamic_object_heap_type::size_type prev_active_size = heap.active_size();
 

--- a/src/gc/reference_count_garbage_collection_scheme.cc
+++ b/src/gc/reference_count_garbage_collection_scheme.cc
@@ -20,7 +20,7 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
-#include "../../include/gc/garbage_collection_scheme.h"
+#include "../../include/gc/reference_count_garbage_collection_scheme.h"
 
 #include <sneaker/algorithm/tarjan.h>
 

--- a/src/gc/reference_count_garbage_collection_scheme.cc
+++ b/src/gc/reference_count_garbage_collection_scheme.cc
@@ -40,19 +40,13 @@ corevm::gc::reference_count_garbage_collection_scheme::gc(
   using _dynamic_object_heap_type = typename
     corevm::gc::reference_count_garbage_collection_scheme::dynamic_object_heap_type;
 
+  ref_count_heap_iterator<_dynamic_object_heap_type> heap_iterator(heap, *this);
+
   _dynamic_object_heap_type::size_type prev_active_size = heap.active_size();
 
   while (true)
   {
-    heap.iterate(
-      [this, &heap](
-        _dynamic_object_heap_type::dynamic_object_id_type id,
-        _dynamic_object_heap_type::dynamic_object_type& object)
-      {
-        this->check_and_dec_ref_count(heap, object);
-        this->resolve_self_reference_cycles(heap, object);
-      }
-    );
+    heap.iterate(heap_iterator);
 
     this->remove_cycles(heap);
 

--- a/src/memory/sequential_allocation_scheme.cc
+++ b/src/memory/sequential_allocation_scheme.cc
@@ -581,16 +581,16 @@ corevm::memory::buddy_allocation_scheme::combine_free_blocks() noexcept
       {
         block_descriptor_type next_block = static_cast<block_descriptor_type>(*next_itr);
 
-        bool isSplit = is_bit_set_uint8(current_block.flags, FLAG_SPLIT) &&
+        bool is_split = is_bit_set_uint8(current_block.flags, FLAG_SPLIT) &&
           !is_bit_set_uint8(next_block.flags, FLAG_SPLIT);
 
-        bool isParentSplit = is_bit_set_uint8(current_block.flags, FLAG_PARENT_SPLIT);
+        bool is_parent_split = is_bit_set_uint8(current_block.flags, FLAG_PARENT_SPLIT);
 
-        if (isSplit && current_block.actual_size == 0 && next_block.actual_size == 0)
+        if (is_split && current_block.actual_size == 0 && next_block.actual_size == 0)
         {
           uint8_t flags = 0;
 
-          if (isParentSplit)
+          if (is_parent_split)
           {
             set_nth_bit_uint8(&flags, FLAG_PARENT_SPLIT);
             set_nth_bit_uint8(&flags, FLAG_SPLIT);

--- a/tests/gc/garbage_collection_unittest.cc
+++ b/tests/gc/garbage_collection_unittest.cc
@@ -23,7 +23,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../../include/dyobj/dynamic_object.h"
 #include "../../include/dyobj/dynamic_object_heap.h"
 #include "../../include/gc/garbage_collector.h"
-#include "../../include/gc/garbage_collection_scheme.h"
+#include "../../include/gc/reference_count_garbage_collection_scheme.h"
 
 #include <sneaker/testing/_unittest.h>
 


### PR DESCRIPTION
* Variable naming convention fixes.
* Moved declarations of `reference_count_garbage_collection_scheme` and `mark_and_sweep_garbage_collection_scheme` into separate files.
* Added heap iterator for ref-count gc scheme.