### PR TITLE
[COREVM-147] Fix dyobj heap max allocation test

### DIFF
--- a/include/dyobj/dynamic_object_heap.h
+++ b/include/dyobj/dynamic_object_heap.h
@@ -52,7 +52,7 @@ public:
 
   typedef corevm::dyobj::dyobj_id dynamic_object_id_type;
   using dynamic_object_type = typename corevm::dyobj::dynamic_object<dynamic_object_manager>;
-  using allocator_type = typename corevm::dyobj::heap_allocator<dynamic_object_type, corevm::memory::buddy_allocation_scheme>;
+  using allocator_type = typename corevm::dyobj::heap_allocator<dynamic_object_type, corevm::memory::first_fit_allocation_scheme>;
   using dynamic_object_container_type = typename corevm::memory::object_container<dynamic_object_type, allocator_type>;
 
   static_assert(
@@ -81,6 +81,8 @@ public:
   size_type size() const noexcept;
 
   size_type max_size() const noexcept;
+
+  size_type total_size() const noexcept;
 
   size_type active_size() const noexcept;
 
@@ -152,6 +154,15 @@ typename corevm::dyobj::dynamic_object_heap<dynamic_object_manager>::size_type
 corevm::dyobj::dynamic_object_heap<dynamic_object_manager>::max_size() const noexcept
 {
   return m_container.max_size();
+}
+
+// -----------------------------------------------------------------------------
+
+template<class dynamic_object_manager>
+typename corevm::dyobj::dynamic_object_heap<dynamic_object_manager>::size_type
+corevm::dyobj::dynamic_object_heap<dynamic_object_manager>::total_size() const noexcept
+{
+  return m_container.total_size();
 }
 
 // -----------------------------------------------------------------------------

--- a/include/memory/object_container.h
+++ b/include/memory/object_container.h
@@ -231,6 +231,8 @@ public:
 
   size_type max_size() const;
 
+  size_type total_size() const;
+
   pointer create();
 
   pointer operator[](pointer);
@@ -315,6 +317,15 @@ typename corevm::memory::object_container<T, AllocatorType>::size_type
 corevm::memory::object_container<T, AllocatorType>::max_size() const
 {
   return m_allocator.max_size();
+}
+
+// -----------------------------------------------------------------------------
+
+template<typename T, typename AllocatorType>
+typename corevm::memory::object_container<T, AllocatorType>::size_type
+corevm::memory::object_container<T, AllocatorType>::total_size() const
+{
+  return m_allocator.total_size();
 }
 
 // -----------------------------------------------------------------------------

--- a/src/memory/sequential_allocation_scheme.cc
+++ b/src/memory/sequential_allocation_scheme.cc
@@ -77,7 +77,7 @@ corevm::memory::sequential_allocation_scheme::debug_print(uint32_t base) const n
   }
   ss << LINE << std::endl;
 
-  std::cout << ss;
+  std::cout << ss.str();
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/dyobj/dynamic_object_heap_unittest.cc
+++ b/tests/dyobj/dynamic_object_heap_unittest.cc
@@ -85,10 +85,10 @@ TEST_F(dynamic_object_heap_unittest, TestAtOnNonExistentKeys)
 
 // -----------------------------------------------------------------------------
 
-// [COREVM-147] Fix dyobj heap max allocation test
-/*
 TEST_F(dynamic_object_heap_unittest, TestAllocationOverMaxSize)
 {
+  /* NOTE: This test may not work if using buddy allocation for the heap. */
+
   auto max_size = m_heap.max_size();
   std::vector<corevm::dyobj::dyobj_id> ids;
 
@@ -110,6 +110,5 @@ TEST_F(dynamic_object_heap_unittest, TestAllocationOverMaxSize)
     m_heap.erase(ids[i]);
   }
 }
-*/
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
This patch fixes the test `dynamic_object_heap_unittest.TestAllocationOverMaxSize`, which was previously disabled. The reason it failed was because the dynamic object heap was using the buddy allocation scheme by default, which creates internal holes that waste part of the allocated memory.

The fix is to switch the default allocation scheme for the heap to the first-fit scheme.

Also exposing the `total_size` interface for both the `object_container` and `dynamic_object_heap`, as facilities debugging and also provides convenience.

Also adds a fix for `sequential_allocation_scheme::debug_print()`.