### PR TITLE
[COREVM-164] Make native types handle allocation size configurable

### DIFF
--- a/include/frontend/configuration.h
+++ b/include/frontend/configuration.h
@@ -27,6 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <sneaker/json/json.h>
 
+#include <cstdint>
 #include <string>
 
 
@@ -49,19 +50,24 @@ public:
 
 public:
   /* Value accessors. */
-  uint64_t alloc_size() const;
+  uint64_t heap_alloc_size() const;
+
+  uint64_t pool_alloc_size() const;
 
   uint32_t gc_interval() const;
 
   /* Value setters. */
-  void set_alloc_size(uint64_t);
+  void set_heap_alloc_size(uint64_t);
+
+  void set_pool_alloc_size(uint64_t);
 
   void set_gc_interval(uint32_t);
 
 private:
   static void set_values(configuration&, const JSON&);
 
-  uint64_t m_alloc_size;
+  uint64_t m_heap_alloc_size;
+  uint64_t m_pool_alloc_size;
   uint32_t m_gc_interval;
 
 private:

--- a/include/frontend/program.h
+++ b/include/frontend/program.h
@@ -47,7 +47,8 @@ protected:
 private:
   std::string m_input_path;
   std::string m_config_path;
-  uint64_t m_alloc_size;
+  uint64_t m_heap_alloc_size;
+  uint64_t m_pool_alloc_size;
   uint32_t m_gc_interval;
 };
 

--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -96,7 +96,7 @@ public:
 
 public:
   process();
-  explicit process(uint64_t);
+  explicit process(uint64_t, uint64_t);
   ~process();
 
   /* Processes should not be copyable. */

--- a/src/frontend/configuration.cc
+++ b/src/frontend/configuration.cc
@@ -45,7 +45,10 @@ const std::string corevm::frontend::configuration::schema = \
   "{"
     "\"type\": \"object\","
     "\"properties\": {"
-      "\"alloc-size\": {"
+      "\"heap-alloc-size\": {"
+        "\"type\": \"integer\""
+      "},"
+      "\"pool-alloc-size\": {"
         "\"type\": \"integer\""
       "},"
       "\"gc-interval\": {"
@@ -58,7 +61,8 @@ const std::string corevm::frontend::configuration::schema = \
 
 corevm::frontend::configuration::configuration()
   :
-  m_alloc_size(0),
+  m_heap_alloc_size(0),
+  m_pool_alloc_size(0),
   m_gc_interval(0)
 {
 }
@@ -66,9 +70,17 @@ corevm::frontend::configuration::configuration()
 // -----------------------------------------------------------------------------
 
 uint64_t
-corevm::frontend::configuration::alloc_size() const
+corevm::frontend::configuration::heap_alloc_size() const
 {
-  return m_alloc_size;
+  return m_heap_alloc_size;
+}
+
+// -----------------------------------------------------------------------------
+
+uint64_t
+corevm::frontend::configuration::pool_alloc_size() const
+{
+  return m_pool_alloc_size;
 }
 
 // -----------------------------------------------------------------------------
@@ -82,9 +94,17 @@ corevm::frontend::configuration::gc_interval() const
 // -----------------------------------------------------------------------------
 
 void
-corevm::frontend::configuration::set_alloc_size(uint64_t alloc_size)
+corevm::frontend::configuration::set_heap_alloc_size(uint64_t heap_alloc_size)
 {
-  m_alloc_size = alloc_size;
+  m_heap_alloc_size = heap_alloc_size;
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::frontend::configuration::set_pool_alloc_size(uint64_t pool_alloc_size)
+{
+  m_pool_alloc_size = pool_alloc_size;
 }
 
 // -----------------------------------------------------------------------------
@@ -174,18 +194,28 @@ corevm::frontend::configuration::set_values(
 
   JSON::object config_obj = config_json.object_items();
 
-  // Set alloc size.
-  if (config_obj.find("alloc-size") != config_obj.end())
+  // Set heap alloc size.
+  if (config_obj.find("heap-alloc-size") != config_obj.end())
   {
-    JSON alloc_size_raw = config_obj.at("alloc-size");
-    configuration.m_alloc_size = static_cast<uint64_t>(alloc_size_raw.int_value());
+    JSON heap_alloc_size_raw = config_obj.at("heap-alloc-size");
+    uint64_t heap_alloc_size = static_cast<uint64_t>(heap_alloc_size_raw.int_value());
+    configuration.set_heap_alloc_size(heap_alloc_size);
+  }
+
+  // Set ntv hndl pool alloc size.
+  if (config_obj.find("pool-alloc-size") != config_obj.end())
+  {
+    JSON pool_alloc_size_raw = config_obj.at("pool-alloc-size");
+    uint64_t pool_alloc_size = static_cast<uint64_t>(pool_alloc_size_raw.int_value());
+    configuration.set_pool_alloc_size(pool_alloc_size);
   }
 
   // GC interval.
   if (config_obj.find("gc-interval") != config_obj.end())
   {
     JSON gc_interval_raw = config_obj.at("gc-interval");
-    configuration.m_gc_interval = static_cast<uint32_t>(gc_interval_raw.int_value());
+    uint32_t gc_interval = static_cast<uint32_t>(gc_interval_raw.int_value());
+    configuration.set_gc_interval(gc_interval);
   }
 }
 

--- a/src/frontend/program.cc
+++ b/src/frontend/program.cc
@@ -40,13 +40,15 @@ corevm::frontend::program::program()
     str(boost::format("coreVM v%s") % COREVM_CANONICAL_VERSION).c_str()),
   m_input_path(),
   m_config_path(),
-  m_alloc_size(0),
+  m_heap_alloc_size(0),
+  m_pool_alloc_size(0),
   m_gc_interval(0)
 {
   add_positional_parameter("input", 1);
   add_string_parameter("input", "Input file", &m_input_path);
   add_string_parameter("config", "Configuration file", &m_config_path);
-  add_uint64_parameter("alloc-size", "Allocation size (bytes)", &m_alloc_size);
+  add_uint64_parameter("heap-alloc-size", "Dynamic Object Heap allocation size (bytes)", &m_heap_alloc_size);
+  add_uint64_parameter("pool-alloc-size", "Native Types Pool allocation size (bytes)", &m_pool_alloc_size);
   add_uint32_parameter("gc-interval", "GC interval (ms)", &m_gc_interval);
 }
 
@@ -70,9 +72,14 @@ corevm::frontend::program::do_run()
     configuration = corevm::frontend::configuration::load_config(m_config_path);
   }
 
-  if (option_provided("alloc-size"))
+  if (option_provided("heap-alloc-size"))
   {
-    configuration.set_alloc_size(m_alloc_size);
+    configuration.set_heap_alloc_size(m_heap_alloc_size);
+  }
+
+  if (option_provided("pool-alloc-size"))
+  {
+    configuration.set_pool_alloc_size(m_pool_alloc_size);
   }
 
   if (option_provided("gc-interval"))

--- a/src/frontend/runner.cc
+++ b/src/frontend/runner.cc
@@ -53,14 +53,17 @@ int
 corevm::frontend::runner::run() const noexcept
 {
   // TODO: [COREVM-163] Refactor configuration default values ingestion
-  // TODO: [COREVM-164] Make native types handle allocation size configurable
+
   uint64_t heap_alloc_size = (
     m_configuration.heap_alloc_size() || corevm::dyobj::COREVM_DEFAULT_HEAP_SIZE);
+
+  uint64_t pool_alloc_size = (
+    m_configuration.pool_alloc_size() || corevm::runtime::COREVM_DEFAULT_NATIVE_TYPES_POOL_SIZE);
 
   uint32_t gc_interval = (
     m_configuration.gc_interval() || corevm::runtime::COREVM_DEFAULT_GC_INTERVAL);
 
-  corevm::runtime::process process(heap_alloc_size);
+  corevm::runtime::process process(heap_alloc_size, pool_alloc_size);
 
   try
   {

--- a/src/frontend/runner.cc
+++ b/src/frontend/runner.cc
@@ -54,13 +54,13 @@ corevm::frontend::runner::run() const noexcept
 {
   // TODO: [COREVM-163] Refactor configuration default values ingestion
   // TODO: [COREVM-164] Make native types handle allocation size configurable
-  uint64_t alloc_size = (
-    m_configuration.alloc_size() || corevm::dyobj::COREVM_DEFAULT_HEAP_SIZE);
+  uint64_t heap_alloc_size = (
+    m_configuration.heap_alloc_size() || corevm::dyobj::COREVM_DEFAULT_HEAP_SIZE);
 
   uint32_t gc_interval = (
     m_configuration.gc_interval() || corevm::runtime::COREVM_DEFAULT_GC_INTERVAL);
 
-  corevm::runtime::process process(alloc_size);
+  corevm::runtime::process process(heap_alloc_size);
 
   try
   {

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -129,12 +129,12 @@ corevm::runtime::process::process()
 
 // -----------------------------------------------------------------------------
 
-corevm::runtime::process::process(uint64_t alloc_size)
+corevm::runtime::process::process(uint64_t heap_alloc_size)
   :
   m_pause_exec(false),
   m_gc_flag(0),
   m_pc(0),
-  m_dynamic_object_heap(alloc_size),
+  m_dynamic_object_heap(heap_alloc_size),
   m_dyobj_stack(),
   m_call_stack(),
   m_ntvhndl_pool(),

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -129,7 +129,7 @@ corevm::runtime::process::process()
 
 // -----------------------------------------------------------------------------
 
-corevm::runtime::process::process(uint64_t heap_alloc_size)
+corevm::runtime::process::process(uint64_t heap_alloc_size, uint64_t pool_alloc_size)
   :
   m_pause_exec(false),
   m_gc_flag(0),
@@ -137,7 +137,7 @@ corevm::runtime::process::process(uint64_t heap_alloc_size)
   m_dynamic_object_heap(heap_alloc_size),
   m_dyobj_stack(),
   m_call_stack(),
-  m_ntvhndl_pool(),
+  m_ntvhndl_pool(pool_alloc_size),
   m_sig_instr_map(),
   m_compartments()
 {

--- a/tests/frontend/configuration_unittest.cc
+++ b/tests/frontend/configuration_unittest.cc
@@ -49,7 +49,8 @@ protected:
   {
     static const std::string content(
       "{"
-        "\"alloc-size\": 1024,"
+        "\"heap-alloc-size\": 2048,"
+        "\"pool-alloc-size\": 1024,"
         "\"gc-interval\": 100"
       "}"
     );
@@ -68,7 +69,8 @@ TEST_F(configuration_unittest, TestLoadSuccessful)
 {
   auto configuration = corevm::frontend::configuration::load_config(PATH);
 
-  ASSERT_EQ(1024, configuration.alloc_size());
+  ASSERT_EQ(2048, configuration.heap_alloc_size());
+  ASSERT_EQ(1024, configuration.pool_alloc_size());
   ASSERT_EQ(100, configuration.gc_interval());
 }
 
@@ -90,16 +92,20 @@ TEST_F(configuration_unittest, TestGetAndSet)
 {
   corevm::frontend::configuration configuration;
 
-  ASSERT_EQ(0, configuration.alloc_size());
+  ASSERT_EQ(0, configuration.heap_alloc_size());
+  ASSERT_EQ(0, configuration.pool_alloc_size());
   ASSERT_EQ(0, configuration.gc_interval());
 
-  uint64_t expected_alloc_size = 1024;
+  uint64_t expected_heap_alloc_size = 2048;
+  uint64_t expected_pool_alloc_size = 1024;
   uint32_t expected_gc_interval = 32;
 
-  configuration.set_alloc_size(expected_alloc_size);
+  configuration.set_heap_alloc_size(expected_heap_alloc_size);
+  configuration.set_pool_alloc_size(expected_pool_alloc_size);
   configuration.set_gc_interval(expected_gc_interval);
 
-  ASSERT_EQ(expected_alloc_size, configuration.alloc_size());
+  ASSERT_EQ(expected_heap_alloc_size, configuration.heap_alloc_size());
+  ASSERT_EQ(expected_pool_alloc_size, configuration.pool_alloc_size());
   ASSERT_EQ(expected_gc_interval, configuration.gc_interval());
 }
 

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -64,9 +64,28 @@ TEST_F(process_unittest, TestStart)
 
 // -----------------------------------------------------------------------------
 
-TEST_F(process_unittest, TestMaxSizes)
+TEST_F(process_unittest, TestDefaultAndMaxSizes)
 {
   corevm::runtime::process process;
+
+  ASSERT_EQ(0, process.heap_size());
+  ASSERT_EQ(0, process.ntvhndl_pool_size());
+
+  ASSERT_LT(0, process.max_heap_size());
+  ASSERT_LT(0, process.max_ntvhndl_pool_size());
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(process_unittest, TestInstantiateWithParameters)
+{
+  uint64_t heap_alloc_size = 2048;
+  uint64_t pool_alloc_size = 1024;
+
+  corevm::runtime::process process(heap_alloc_size, pool_alloc_size);
+
+  ASSERT_EQ(0, process.heap_size());
+  ASSERT_EQ(0, process.ntvhndl_pool_size());
 
   ASSERT_LT(0, process.max_heap_size());
   ASSERT_LT(0, process.max_ntvhndl_pool_size());


### PR DESCRIPTION
Make the allocation size of the native types handle configurable, and ingests it into the process.

![corevm](https://cloud.githubusercontent.com/assets/554685/6345166/6976f404-bbb7-11e4-98e9-bdb577e4a46a.png)
