### PR TITLE
[COREVM-167] Floating point execution core dump

### DIFF
--- a/include/runtime/common.h
+++ b/include/runtime/common.h
@@ -43,7 +43,7 @@ typedef int32_t instr_addr;
 typedef uint16_t instr_code;
 
 
-typedef int64_t instr_oprd;
+typedef uint64_t instr_oprd;
 
 
 typedef int32_t variable_key;

--- a/include/runtime/common.h
+++ b/include/runtime/common.h
@@ -43,7 +43,7 @@ typedef int32_t instr_addr;
 typedef uint16_t instr_code;
 
 
-typedef uint64_t instr_oprd;
+typedef int64_t instr_oprd;
 
 
 typedef int32_t variable_key;

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -512,14 +512,20 @@ enum instr_enum : uint32_t
   BOOL,
 
   /**
-   * <dec1, #, _>
+   * <dec1, #, #>
    * Creates an instance of type `dec` and place it on top of eval stack.
+   * The first operand represents the whole number part, while the second
+   * operand represents the decimal part, expressed as integer in reverse
+   * order.
    */
   DEC1,
 
   /**
-   * <dec2, #, _>
+   * <dec2, #, #>
    * Creates an instance of type `dec2` and place it on top of eval stack.
+   * The first operand represents the whole number part, while the second
+   * operand represents the decimal part, expressed as integer in reverse
+   * order.
    */
   DEC2,
 
@@ -897,7 +903,11 @@ protected:
     const corevm::runtime::instr&, corevm::runtime::process&);
 
   template<typename NativeType>
-  void execute_native_type_creation_instr(
+  void execute_native_floating_type_creation_instr(
+    const corevm::runtime::instr&, corevm::runtime::process&);
+
+  template<typename NativeType>
+  void execute_native_complex_type_creation_instr(
     const corevm::runtime::instr&, corevm::runtime::process&);
 
   template<typename InterfaceFunc>

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -893,6 +893,10 @@ protected:
     const corevm::runtime::instr&, corevm::runtime::process&, InterfaceFunc);
 
   template<typename NativeType>
+  void execute_native_integer_type_creation_instr(
+    const corevm::runtime::instr&, corevm::runtime::process&);
+
+  template<typename NativeType>
   void execute_native_type_creation_instr(
     const corevm::runtime::instr&, corevm::runtime::process&);
 

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -96,8 +96,8 @@ class BytecodeGenerator(ast.NodeVisitor):
     """ ----------------------------- expr --------------------------------- """
 
     def visit_BinOp(self, node):
-        self.visit(node.left)
         self.visit(node.right)
+        self.visit(node.left)
         self.visit(node.op)
 
     def visit_Num(self, node):

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -27,6 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <boost/format.hpp>
 
+#include <algorithm>
 #include <cassert>
 #include <csignal>
 #include <cstdlib>
@@ -34,7 +35,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <iostream>
 #include <memory>
 #include <ostream>
+#include <sstream>
 #include <stdexcept>
+#include <string>
 
 
 // -----------------------------------------------------------------------------
@@ -321,7 +324,30 @@ corevm::runtime::instr_handler::execute_native_integer_type_creation_instr(
 
 template<typename NativeType>
 void
-corevm::runtime::instr_handler::execute_native_type_creation_instr(
+corevm::runtime::instr_handler::execute_native_floating_type_creation_instr(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  corevm::runtime::frame& frame = process.top_frame();
+
+  std::stringstream oprd2_ss;
+  oprd2_ss << instr.oprd2;
+  std::string oprd2_str = oprd2_ss.str();
+
+  std::reverse(oprd2_str.begin(), oprd2_str.end());
+
+  std::stringstream ss;
+  ss << instr.oprd1 << "." << oprd2_str;
+
+  corevm::types::native_type_handle hndl = NativeType(stod(ss.str()));
+
+  frame.push_eval_stack(hndl);
+}
+
+// -----------------------------------------------------------------------------
+
+template<typename NativeType>
+void
+corevm::runtime::instr_handler::execute_native_complex_type_creation_instr(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
   corevm::runtime::frame& frame = process.top_frame();
@@ -1526,7 +1552,7 @@ void
 corevm::runtime::instr_handler_dec1::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::decimal>(
+  corevm::runtime::instr_handler::execute_native_floating_type_creation_instr<corevm::types::decimal>(
     instr,
     process
   );
@@ -1538,7 +1564,7 @@ void
 corevm::runtime::instr_handler_dec2::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::decimal2>(
+  corevm::runtime::instr_handler::execute_native_floating_type_creation_instr<corevm::types::decimal2>(
     instr,
     process
   );
@@ -1550,7 +1576,7 @@ void
 corevm::runtime::instr_handler_str::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::string>(
+  corevm::runtime::instr_handler::execute_native_complex_type_creation_instr<corevm::types::string>(
     instr,
     process
   );
@@ -1562,7 +1588,7 @@ void
 corevm::runtime::instr_handler_ary::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::array>(
+  corevm::runtime::instr_handler::execute_native_complex_type_creation_instr<corevm::types::array>(
     instr,
     process
   );
@@ -1574,7 +1600,7 @@ void
 corevm::runtime::instr_handler_map::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::map>(
+  corevm::runtime::instr_handler::execute_native_complex_type_creation_instr<corevm::types::map>(
     instr,
     process
   );

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -307,6 +307,20 @@ corevm::runtime::instr_handler::execute_binary_operator_instr(
 
 template<typename NativeType>
 void
+corevm::runtime::instr_handler::execute_native_integer_type_creation_instr(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  corevm::runtime::frame& frame = process.top_frame();
+
+  corevm::types::native_type_handle hndl = NativeType(instr.oprd1);
+
+  frame.push_eval_stack(hndl);
+}
+
+// -----------------------------------------------------------------------------
+
+template<typename NativeType>
+void
 corevm::runtime::instr_handler::execute_native_type_creation_instr(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
@@ -1404,7 +1418,7 @@ void
 corevm::runtime::instr_handler_int8::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::int8>(
+  corevm::runtime::instr_handler::execute_native_integer_type_creation_instr<corevm::types::int8>(
     instr,
     process
   );
@@ -1416,7 +1430,7 @@ void
 corevm::runtime::instr_handler_uint8::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::uint8>(
+  corevm::runtime::instr_handler::execute_native_integer_type_creation_instr<corevm::types::uint8>(
     instr,
     process
   );
@@ -1428,7 +1442,7 @@ void
 corevm::runtime::instr_handler_int16::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::int16>(
+  corevm::runtime::instr_handler::execute_native_integer_type_creation_instr<corevm::types::int16>(
     instr,
     process
   );
@@ -1440,7 +1454,7 @@ void
 corevm::runtime::instr_handler_uint16::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::uint16>(
+  corevm::runtime::instr_handler::execute_native_integer_type_creation_instr<corevm::types::uint16>(
     instr,
     process
   );
@@ -1452,7 +1466,7 @@ void
 corevm::runtime::instr_handler_int32::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::int32>(
+  corevm::runtime::instr_handler::execute_native_integer_type_creation_instr<corevm::types::int32>(
     instr,
     process
   );
@@ -1464,7 +1478,7 @@ void
 corevm::runtime::instr_handler_uint32::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::uint32>(
+  corevm::runtime::instr_handler::execute_native_integer_type_creation_instr<corevm::types::uint32>(
     instr,
     process
   );
@@ -1476,7 +1490,7 @@ void
 corevm::runtime::instr_handler_int64::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::int64>(
+  corevm::runtime::instr_handler::execute_native_integer_type_creation_instr<corevm::types::int64>(
     instr,
     process
   );
@@ -1488,7 +1502,7 @@ void
 corevm::runtime::instr_handler_uint64::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::uint64>(
+  corevm::runtime::instr_handler::execute_native_integer_type_creation_instr<corevm::types::uint64>(
     instr,
     process
   );
@@ -1500,7 +1514,7 @@ void
 corevm::runtime::instr_handler_bool::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::instr_handler::execute_native_type_creation_instr<corevm::types::boolean>(
+  corevm::runtime::instr_handler::execute_native_integer_type_creation_instr<corevm::types::boolean>(
     instr,
     process
   );

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -34,6 +34,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <climits>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <list>
 
 
@@ -1124,6 +1125,27 @@ protected:
     ASSERT_EQ(expected_result, actual_result);
   }
 
+  template<typename InstrHandlerCls, typename IntrinsicType=uint32_t>
+  void execute_instr_and_assert_result_equals_operand(const corevm::runtime::instr& instr)
+  {
+    InstrHandlerCls instr_handler;
+
+    instr_handler.execute(instr, m_process);
+
+    corevm::runtime::frame& frame = m_process.top_frame();
+    ASSERT_EQ(m_expected_eval_stack_size, frame.eval_stack_size());
+
+    corevm::types::native_type_handle result_handle = frame.pop_eval_stack();
+
+    IntrinsicType expected_result = static_cast<IntrinsicType>(instr.oprd1);
+
+    IntrinsicType actual_result = corevm::types::get_value_from_handle<IntrinsicType>(
+      result_handle
+    );
+
+    ASSERT_EQ(expected_result, actual_result);
+  }
+
   uint32_t m_expected_eval_stack_size = 1;
   corevm::runtime::process m_process;
   corevm::runtime::frame* m_frame = new corevm::runtime::frame(m_ctx);
@@ -1365,7 +1387,7 @@ class instrs_native_types_instrs_test : public instrs_eval_stack_instrs_test {};
 
 // -----------------------------------------------------------------------------
 
-class instrs_native_type_creation_instrs_test : public instrs_native_types_instrs_test
+class instrs_native_integer_type_creation_instrs_test : public instrs_native_types_instrs_test
 {
 public:
   virtual void SetUp()
@@ -1376,66 +1398,140 @@ public:
 
 // -----------------------------------------------------------------------------
 
-TEST_F(instrs_native_type_creation_instrs_test, TestInstrINT8)
+TEST_F(instrs_native_integer_type_creation_instrs_test, TestInstrINT8)
 {
-  execute_instr_and_assert_result<corevm::runtime::instr_handler_int8, int8_t>(0);
+  corevm::runtime::instr instr {
+    .code = corevm::runtime::instr_enum::INT8,
+    .oprd1 = std::numeric_limits<int8_t>::max(),
+    .oprd2 = 0
+  };
+
+  execute_instr_and_assert_result_equals_operand<
+    corevm::runtime::instr_handler_int8, int8_t>(instr);
 }
 
 // -----------------------------------------------------------------------------
 
-TEST_F(instrs_native_type_creation_instrs_test, TestInstrUINT8)
+TEST_F(instrs_native_integer_type_creation_instrs_test, TestInstrUINT8)
 {
-  execute_instr_and_assert_result<corevm::runtime::instr_handler_uint8, uint8_t>(0);
+  corevm::runtime::instr instr {
+    .code = corevm::runtime::instr_enum::UINT8,
+    .oprd1 = std::numeric_limits<uint8_t>::max(),
+    .oprd2 = 0
+  };
+
+  execute_instr_and_assert_result_equals_operand<
+    corevm::runtime::instr_handler_uint8, uint8_t>(instr);
 }
 
 // -----------------------------------------------------------------------------
 
-TEST_F(instrs_native_type_creation_instrs_test, TestInstrINT16)
+TEST_F(instrs_native_integer_type_creation_instrs_test, TestInstrINT16)
 {
-  execute_instr_and_assert_result<corevm::runtime::instr_handler_int16, int16_t>(0);
+  corevm::runtime::instr instr {
+    .code = corevm::runtime::instr_enum::INT16,
+    .oprd1 = std::numeric_limits<int16_t>::max(),
+    .oprd2 = 0
+  };
+
+  execute_instr_and_assert_result_equals_operand
+    <corevm::runtime::instr_handler_int16, int16_t>(instr);
 }
 
 // -----------------------------------------------------------------------------
 
-TEST_F(instrs_native_type_creation_instrs_test, TestInstrUINT16)
+TEST_F(instrs_native_integer_type_creation_instrs_test, TestInstrUINT16)
 {
-  execute_instr_and_assert_result<corevm::runtime::instr_handler_uint16, uint16_t>(0);
+  corevm::runtime::instr instr {
+    .code = corevm::runtime::instr_enum::UINT16,
+    .oprd1 = std::numeric_limits<uint16_t>::max(),
+    .oprd2 = 0
+  };
+
+  execute_instr_and_assert_result_equals_operand<
+    corevm::runtime::instr_handler_uint16, uint16_t>(instr);
 }
 
 // -----------------------------------------------------------------------------
 
-TEST_F(instrs_native_type_creation_instrs_test, TestInstrINT32)
+TEST_F(instrs_native_integer_type_creation_instrs_test, TestInstrINT32)
 {
-  execute_instr_and_assert_result<corevm::runtime::instr_handler_int32, int32_t>(0);
+  corevm::runtime::instr instr {
+    .code = corevm::runtime::instr_enum::INT32,
+    .oprd1 = std::numeric_limits<int32_t>::max(),
+    .oprd2 = 0
+  };
+
+  execute_instr_and_assert_result_equals_operand<
+    corevm::runtime::instr_handler_int32, int32_t>(instr);
 }
 
 // -----------------------------------------------------------------------------
 
-TEST_F(instrs_native_type_creation_instrs_test, TestInstrUINT32)
+TEST_F(instrs_native_integer_type_creation_instrs_test, TestInstrUINT32)
 {
-  execute_instr_and_assert_result<corevm::runtime::instr_handler_uint32, uint32_t>(0);
+  corevm::runtime::instr instr {
+    .code = corevm::runtime::instr_enum::UINT32,
+    .oprd1 = std::numeric_limits<uint32_t>::max(),
+    .oprd2 = 0
+  };
+
+  execute_instr_and_assert_result_equals_operand<
+    corevm::runtime::instr_handler_uint32, uint32_t>(instr);
 }
 
 // -----------------------------------------------------------------------------
 
-TEST_F(instrs_native_type_creation_instrs_test, TestInstrINT64)
+TEST_F(instrs_native_integer_type_creation_instrs_test, TestInstrINT64)
 {
-  execute_instr_and_assert_result<corevm::runtime::instr_handler_int64, int64_t>(0);
+  corevm::runtime::instr instr {
+    .code = corevm::runtime::instr_enum::INT64,
+    .oprd1 = std::numeric_limits<int64_t>::max(),
+    .oprd2 = 0
+  };
+
+  execute_instr_and_assert_result_equals_operand<
+    corevm::runtime::instr_handler_int64, int64_t>(instr);
 }
 
 // -----------------------------------------------------------------------------
 
-TEST_F(instrs_native_type_creation_instrs_test, TestInstrUINT64)
+TEST_F(instrs_native_integer_type_creation_instrs_test, TestInstrUINT64)
 {
-  execute_instr_and_assert_result<corevm::runtime::instr_handler_uint64, uint64_t>(0);
+  corevm::runtime::instr instr {
+    .code = corevm::runtime::instr_enum::UINT64,
+    .oprd1 = std::numeric_limits<uint64_t>::max(),
+    .oprd2 = 0
+  };
+
+  execute_instr_and_assert_result_equals_operand<
+    corevm::runtime::instr_handler_uint64, uint64_t>(instr);
 }
 
 // -----------------------------------------------------------------------------
 
-TEST_F(instrs_native_type_creation_instrs_test, TestInstrBOOL)
+TEST_F(instrs_native_integer_type_creation_instrs_test, TestInstrBOOL)
 {
-  execute_instr_and_assert_result<corevm::runtime::instr_handler_bool, bool>(true);
+  corevm::runtime::instr instr {
+    .code = corevm::runtime::instr_enum::BOOL,
+    .oprd1 = 1,
+    .oprd2 = 0
+  };
+
+  execute_instr_and_assert_result_equals_operand<
+    corevm::runtime::instr_handler_bool, bool>(instr);
 }
+
+// -----------------------------------------------------------------------------
+
+class instrs_native_type_creation_instrs_test : public instrs_native_types_instrs_test
+{
+public:
+  virtual void SetUp()
+  {
+    push_eval_stack_and_frame(eval_oprds_list{});
+  }
+};
 
 // -----------------------------------------------------------------------------
 

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -1146,6 +1146,26 @@ protected:
     ASSERT_EQ(expected_result, actual_result);
   }
 
+  template<typename InstrHandlerCls, typename IntrinsicType>
+  void execute_native_floating_type_creation_instr_and_assert_result(
+    const corevm::runtime::instr& instr, IntrinsicType expected_result)
+  {
+    InstrHandlerCls instr_handler;
+
+    instr_handler.execute(instr, m_process);
+
+    corevm::runtime::frame& frame = m_process.top_frame();
+    ASSERT_EQ(m_expected_eval_stack_size, frame.eval_stack_size());
+
+    corevm::types::native_type_handle result_handle = frame.pop_eval_stack();
+
+    IntrinsicType actual_result = corevm::types::get_value_from_handle<IntrinsicType>(
+      result_handle
+    );
+
+    ASSERT_DOUBLE_EQ(expected_result, actual_result);
+  }
+
   uint32_t m_expected_eval_stack_size = 1;
   corevm::runtime::process m_process;
   corevm::runtime::frame* m_frame = new corevm::runtime::frame(m_ctx);
@@ -1537,14 +1557,28 @@ public:
 
 TEST_F(instrs_native_type_creation_instrs_test, TestInstrDEC1)
 {
-  execute_instr_and_assert_result<corevm::runtime::instr_handler_dec1, float>(0.0);
+  corevm::runtime::instr instr {
+    .code = corevm::runtime::instr_enum::DEC1,
+    .oprd1 = 12345,
+    .oprd2 = 98760
+  };
+
+  execute_native_floating_type_creation_instr_and_assert_result<
+    corevm::runtime::instr_handler_dec1, float>(instr, 12345.06789);
 }
 
 // -----------------------------------------------------------------------------
 
 TEST_F(instrs_native_type_creation_instrs_test, TestInstrDEC2)
 {
-  execute_instr_and_assert_result<corevm::runtime::instr_handler_dec2, double>(0.0);
+  corevm::runtime::instr instr {
+    .code = corevm::runtime::instr_enum::DEC2,
+    .oprd1 = 1234567890,
+    .oprd2 = 9876543210
+  };
+
+  execute_native_floating_type_creation_instr_and_assert_result<
+    corevm::runtime::instr_handler_dec2, double>(instr, 1234567890.0123456789);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
This patch fixes the problem of floating point execution core dump when encountering division and modulus operations in Python tests.

The problem was that the native type creation instructions did not take the operands as the value of a native type when creating it on the evaluation stack. This accounts for both the native integer and floating types. Therefore, although the types were created, they all had a value of zero, and that's why the floating point execution core dump happened, because the value of zero were used for division and modulus operations,

The solution is to fix those instruction handlers to use the value of the operand when creating an instance of the type. The value of the first operand is used for creating integer types, while both operands are used for floating types. 