### PR TITLE
[COREVM-169] Add support for functional call arguments in Python tests [PART I]

### DIFF
--- a/include/runtime/frame.h
+++ b/include/runtime/frame.h
@@ -99,6 +99,8 @@ public:
 
   bool has_param_value_pairs() const;
 
+  bool has_param_value_pair_with_key(const corevm::runtime::variable_key) const;
+
   void put_param_value_pair(const corevm::runtime::variable_key, const corevm::dyobj::dyobj_id&);
 
   const corevm::dyobj::dyobj_id pop_param_value_pair(const corevm::runtime::variable_key)

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -251,8 +251,8 @@ enum instr_enum : uint32_t
   /**
    * <getkwarg, key, addr>
    * If the top frame has the keyword-argument pair with the key specified
-   * as the first operand, pops off the pair and put it on top of the stack.
-   * Otherwise, advance the program counter by the value specified in the
+   * as the first operand, pops off the pair and put the value on top of the
+   * stack. Otherwise, advance the program counter by the value specified in the
    * second operand.
    */
   GETKWARG,

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -249,9 +249,11 @@ enum instr_enum : uint32_t
   GETARG,
 
   /**
-   * <getkwarg, key, _>
-   * Pops off the keyword-argument for the current call with the specified
-   * key and put it on top of the stack.
+   * <getkwarg, key, addr>
+   * If the top frame has the keyword-argument pair with the key specified
+   * as the first operand, pops off the pair and put it on top of the stack.
+   * Otherwise, advance the program counter by the value specified in the
+   * second operand.
    */
   GETKWARG,
 

--- a/python/src/call.py
+++ b/python/src/call.py
@@ -1,7 +1,7 @@
 def do_math():
   1 + 1
 
-def hello_world():
+def hello_world(arg1, arg2, warg1=1+1, *argss, **kwargss):
   do_math()
 
 hello_world()

--- a/src/runtime/frame.cc
+++ b/src/runtime/frame.cc
@@ -235,6 +235,15 @@ corevm::runtime::frame::has_param_value_pairs() const
 
 // -----------------------------------------------------------------------------
 
+bool
+corevm::runtime::frame::has_param_value_pair_with_key(
+  const corevm::runtime::variable_key key) const
+{
+  return m_param_value_map.find(key) != m_param_value_map.end();
+}
+
+// -----------------------------------------------------------------------------
+
 void
 corevm::runtime::frame::put_param_value_pair(
   const corevm::runtime::variable_key key, const corevm::dyobj::dyobj_id& id)

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -1048,9 +1048,17 @@ corevm::runtime::instr_handler_getkwarg::execute(
 {
   corevm::runtime::frame& frame = process.top_frame();
   corevm::runtime::variable_key key = static_cast<corevm::runtime::variable_key>(instr.oprd1);
-  corevm::dyobj::dyobj_id id = frame.pop_param_value_pair(key);
 
-  process.push_stack(id);
+  if (frame.has_param_value_pair_with_key(key))
+  {
+    corevm::dyobj::dyobj_id id = frame.pop_param_value_pair(key);
+    process.push_stack(id);
+  }
+  else
+  {
+    instr_addr relative_addr = static_cast<instr_addr>(instr.oprd2);
+    process.set_pc(process.pc() + relative_addr);
+  }
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Support for function calls in Python tests was added in #96, which does not support call arguments. This continues that to add the support for function call arguments.

This branch is part I of the task, as it only covers handling for function/lambda parameters. There will be a following patch to handle function call arguments.