### PR TITLE
[COREVM-169] Add support for functional call arguments in Python tests [PART II]

### DIFF
--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -242,6 +242,25 @@ enum instr_enum : uint32_t
   PUTKWARG,
 
   /**
+   * <putargs, _, _>
+   * Pops the top object off the stack, retrieves its native type handle
+   * as a native type array, and then iterate through each array element,
+   * use it as an object ID to retrieve an object from the heap, and assigns
+   * it as the next argument for the next call.
+   */
+  PUTARGS,
+
+  /**
+   * <putkwargs, _, _>
+   * Pops the top object off the stack, retrieves its native type handle
+   * as a native type map, and then iterate through each key-value pair,
+   * use the value as an object ID to retrieve an object from the heap,
+   * and use the key as an encoding ID to assign the object as the next
+   * keyword-argument for the next call.
+   */
+  PUTKWARGS,
+
+  /**
    * <getarg, _, _>
    * Pops off the first argument for the current call and put it on
    * top of the stack.
@@ -1178,6 +1197,22 @@ public:
 // -----------------------------------------------------------------------------
 
 class instr_handler_putkwarg : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_putargs : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_putkwargs : public instr_handler
 {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -183,9 +183,12 @@ class BytecodeGenerator(ast.NodeVisitor):
 
         self.current_closure_name = name
 
+        # Off-load arguments.
+        self.visit(node.args)
+
+        # Statements.
         for stmt in node.body:
             self.visit(stmt)
-        self.visit(node.args)
 
         # step out
         self.current_closure_name = self.closure_map[self.current_closure_name].parent_name
@@ -380,7 +383,7 @@ class BytecodeGenerator(ast.NodeVisitor):
             for arg in node.args:
                 if closest_arg is None:
                     closest_arg = arg
-                elif arg.col_offset < closest_arg.col_offset and arg.col_offset < default.col_offset:
+                elif arg.col_offset > closest_arg.col_offset and arg.col_offset < default.col_offset:
                     closest_arg = arg
 
             assert closest_arg

--- a/python/src/call.py
+++ b/python/src/call.py
@@ -1,7 +1,7 @@
 def do_math():
   1 + 1
 
-def hello_world(arg1, arg2, warg1=1+1, *argss, **kwargss):
+def hello_world(arg1, arg2, kwarg1=1+1, *args, **kwargs):
   do_math()
 
-hello_world()
+hello_world(1, 2, kwarg1=3, *args, **kwargs)

--- a/python/src/call.py
+++ b/python/src/call.py
@@ -1,8 +1,7 @@
-def do_math():
+def do_math(*args):
   1 + 1
 
 def hello_world(arg1, arg2, kwarg1=1+1, *args, **kwargs):
-  pass
-  #do_math()
+  do_math(arg1)
 
 hello_world(1, 2, kwarg1=3)

--- a/python/src/call.py
+++ b/python/src/call.py
@@ -2,6 +2,7 @@ def do_math():
   1 + 1
 
 def hello_world(arg1, arg2, kwarg1=1+1, *args, **kwargs):
-  do_math()
+  pass
+  #do_math()
 
-hello_world(1, 2, kwarg1=3, *args, **kwargs)
+hello_world(1, 2, kwarg1=3)

--- a/src/runtime/frame.cc
+++ b/src/runtime/frame.cc
@@ -220,8 +220,8 @@ corevm::runtime::frame::pop_param() throw(corevm::runtime::missing_parameter_err
     throw corevm::runtime::missing_parameter_error();
   }
 
-  corevm::dyobj::dyobj_id id = m_params_list.back();
-  m_params_list.pop_back();
+  corevm::dyobj::dyobj_id id = m_params_list.front();
+  m_params_list.pop_front();
   return id;
 }
 

--- a/tests/runtime/frame_unittest.cc
+++ b/tests/runtime/frame_unittest.cc
@@ -144,11 +144,11 @@ TEST_F(frame_unittest, TestPutAndGetParams)
 
   ASSERT_EQ(false, frame.has_params());
 
-  corevm::dyobj::dyobj_id id2 = 200;
   corevm::dyobj::dyobj_id id1 = 1000;
+  corevm::dyobj::dyobj_id id2 = 200;
 
-  frame.put_param(id2);
   frame.put_param(id1);
+  frame.put_param(id2);
 
   ASSERT_EQ(true, frame.has_params());
 

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -679,6 +679,90 @@ TEST_F(instrs_functions_instrs_test, TestInstrPUTKWARG)
 
 // -----------------------------------------------------------------------------
 
+TEST_F(instrs_functions_instrs_test, TestInstrPUTARGS)
+{
+  corevm::runtime::frame frame(m_ctx);
+  m_process.push_frame(frame);
+
+  corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();
+  auto& obj = process::adapter(m_process).help_get_dyobj(id);
+
+  corevm::dyobj::dyobj_id id1 = process::adapter(m_process).help_create_dyobj();
+  corevm::dyobj::dyobj_id id2 = process::adapter(m_process).help_create_dyobj();
+  corevm::dyobj::dyobj_id id3 = process::adapter(m_process).help_create_dyobj();
+
+  corevm::types::native_type_handle hndl = corevm::types::native_array {
+    id1,
+    id2,
+    id3
+  };
+
+  auto key = m_process.insert_ntvhndl(hndl);
+  obj.set_ntvhndl_key(key);
+
+  m_process.push_stack(id);
+
+  corevm::runtime::frame& actual_frame = m_process.top_frame();
+
+  corevm::runtime::instr instr { .code=0, .oprd1=0, .oprd2=0 };
+  corevm::runtime::instr_handler_putargs handler;
+  handler.execute(instr, m_process);
+
+  corevm::dyobj::dyobj_id arg_id1 = actual_frame.pop_param();
+  corevm::dyobj::dyobj_id arg_id2 = actual_frame.pop_param();
+  corevm::dyobj::dyobj_id arg_id3 = actual_frame.pop_param();
+
+  ASSERT_EQ(id1, arg_id1);
+  ASSERT_EQ(id2, arg_id2);
+  ASSERT_EQ(id3, arg_id3);
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(instrs_functions_instrs_test, TestInstrPUTKWARGS)
+{
+  corevm::runtime::frame frame(m_ctx);
+  m_process.push_frame(frame);
+
+  corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();
+  auto& obj = process::adapter(m_process).help_get_dyobj(id);
+
+  corevm::dyobj::dyobj_id id1 = process::adapter(m_process).help_create_dyobj();
+  corevm::dyobj::dyobj_id id2 = process::adapter(m_process).help_create_dyobj();
+  corevm::dyobj::dyobj_id id3 = process::adapter(m_process).help_create_dyobj();
+
+  corevm::runtime::variable_key key1 = 1;
+  corevm::runtime::variable_key key2 = 2;
+  corevm::runtime::variable_key key3 = 3;
+
+  corevm::types::native_type_handle hndl = corevm::types::native_map {
+    { key1, id1 },
+    { key2, id2 },
+    { key3, id3 }
+  };
+
+  auto key = m_process.insert_ntvhndl(hndl);
+  obj.set_ntvhndl_key(key);
+
+  m_process.push_stack(id);
+
+  corevm::runtime::frame& actual_frame = m_process.top_frame();
+
+  corevm::runtime::instr instr { .code=0, .oprd1=0, .oprd2=0 };
+  corevm::runtime::instr_handler_putkwargs handler;
+  handler.execute(instr, m_process);
+
+  corevm::dyobj::dyobj_id arg_id1 = actual_frame.pop_param_value_pair(key1);
+  corevm::dyobj::dyobj_id arg_id2 = actual_frame.pop_param_value_pair(key2);
+  corevm::dyobj::dyobj_id arg_id3 = actual_frame.pop_param_value_pair(key3);
+
+  ASSERT_EQ(id1, arg_id1);
+  ASSERT_EQ(id2, arg_id2);
+  ASSERT_EQ(id3, arg_id3);
+}
+
+// -----------------------------------------------------------------------------
+
 TEST_F(instrs_functions_instrs_test, TestInstrGETARG)
 {
   corevm::dyobj::dyobj_id id = 1;
@@ -751,13 +835,13 @@ TEST_F(instrs_functions_instrs_test, TestInstrGETARGS)
   corevm::types::native_type_handle result_handle2;
   corevm::types::native_type_handle result_handle3;
 
-  corevm::types::interface_array_back(hndl, result_handle1);
+  corevm::types::interface_array_back(hndl, result_handle3);
   corevm::types::interface_array_pop(hndl, hndl);
 
   corevm::types::interface_array_back(hndl, result_handle2);
   corevm::types::interface_array_pop(hndl, hndl);
 
-  corevm::types::interface_array_back(hndl, result_handle3);
+  corevm::types::interface_array_back(hndl, result_handle1);
   corevm::types::interface_array_pop(hndl, hndl);
 
   corevm::dyobj::dyobj_id actual_id1 = corevm::types::get_value_from_handle<corevm::dyobj::dyobj_id>(result_handle1);


### PR DESCRIPTION
Support for accepting arguments from a function/lambda definition was added in #101. This patch continues to add support for function calls by supporting assigning argument and keyword-argument values for function calls. 

Following this patch, we now have full support for function calls in Python with arguments and keyword-arguments support.

```
                                 .''.
       .''.             *''*    :_\/_:     .
      :_\/_:   .    .:.*_\/_*   : /\ :  .'.:.'.
  .''.: /\ : _\(/_  ':'* /\ *  : '..'.  -=:o:=-
 :_\/_:'.:::. /)\*''*  .|.* '.\'/.'_\(/_'.':'.'
 : /\ : :::::  '*_\/_* | |  -= o =- /)\    '  *
  '..'  ':::'   * /\ * |'|  .'/.\'.  '._____
      *        __*..* |  |     :      |.   |' .---"|
       _*   .-'   '-. |  |     .--'|  ||   | _|    |
    .-'|  _.|  |    ||   '-__  |   |  |    ||      |
    |' | |.    |    ||       | |   |  |    ||      |
 ___|  '-'     '    ""       '-'   '-.'    '`      |____
*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *

```