### PR TITLE
[COREVM-175] Consolidate and fix the way program counter gets updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ INCLUDE=./include
 SRC=./src
 TESTS=./tests
 TOOLS=./tools
+PYTHON_DIR=./python
 
 SUBDIRS=$(SRC) $(TESTS)
 
@@ -56,6 +57,8 @@ ifeq ($(UNAME_S), Darwin)
 	LFLAGS += -lboost_system-mt -lboost_regex-mt -lboost_program_options
 endif
 
+PYTHON=`which python`
+BOOTSTRAP_TESTS=bootstrap_tests.py
 
 export GTEST_COLOR=true
 
@@ -77,6 +80,10 @@ test:
 .PHONY: tools
 tools:
 	@$(MAKE) -C $(TOOLS)
+
+.PHONY: python
+python:
+	@$(PYTHON) $(PYTHON_DIR)/$(BOOTSTRAP_TESTS)
 
 .PHONY: clean
 clean:

--- a/include/runtime/frame.h
+++ b/include/runtime/frame.h
@@ -60,9 +60,9 @@ public:
 
   uint32_t eval_stack_size() const;
 
-  corevm::runtime::instr_addr get_start_addr() const;
+  corevm::runtime::instr_addr start_addr() const;
 
-  corevm::runtime::instr_addr get_return_addr() const;
+  corevm::runtime::instr_addr return_addr() const;
 
   void set_return_addr(const corevm::runtime::instr_addr);
 

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -304,6 +304,13 @@ enum instr_enum : uint32_t
    */
   DEBUG,
 
+  /**
+   * <print, _, _>
+   * Converts the native type handle associated with the object on top of the
+   * stack into a native string, and prints it to std output.
+   */
+  PRINT,
+
   /* ------------------ Arithmetic and logic instructions ------------------- */
 
   /**
@@ -1267,6 +1274,14 @@ public:
 // -----------------------------------------------------------------------------
 
 class instr_handler_debug : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_print: public instr_handler
 {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -908,6 +908,10 @@ std::ostream& operator<<(std::ostream&, const corevm::runtime::instr&);
 
 // -----------------------------------------------------------------------------
 
+bool operator==(const instr&, const instr&);
+
+// -----------------------------------------------------------------------------
+
 // Forward declaration of `corevm::runtime::process`.
 class process;
 

--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -103,8 +103,6 @@ public:
   process(const process&) = delete;
   process& operator=(const process&) = delete;
 
-  const corevm::runtime::instr_addr current_addr() const;
-
   uint64_t call_stack_size() const;
 
   bool has_frame() const;
@@ -182,6 +180,8 @@ public:
   friend std::ostream& operator<<(std::ostream&, const corevm::runtime::process&);
 
 private:
+  bool is_valid_pc() const;
+
   bool pre_start();
 
   bool should_gc() const;

--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -142,6 +142,8 @@ public:
 
   void append_vector(const corevm::runtime::vector&);
 
+  void insert_vector(corevm::runtime::vector& vector);
+
   void get_frame_by_closure_ctx(
     corevm::runtime::closure_ctx&, corevm::runtime::frame**);
 
@@ -185,8 +187,6 @@ private:
   bool pre_start();
 
   bool should_gc() const;
-
-  void insert_vector(corevm::runtime::vector& vector);
 
   bool m_pause_exec;
   uint8_t m_gc_flag;

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -46,7 +46,8 @@ class Instr(object):
 
 class Closure(object):
 
-    __closure_id = 0
+    # Has to be a non-zero value.
+    __closure_id = 1
 
     def __init__(self, name, parent_name, parent_id):
         self.name = name
@@ -190,6 +191,9 @@ class BytecodeGenerator(ast.NodeVisitor):
         for stmt in node.body:
             self.visit(stmt)
 
+        # Explicit return.
+        self.__add_instr('rtrn', 0, 0)
+
         # step out
         self.current_closure_name = self.closure_map[self.current_closure_name].parent_name
 
@@ -198,6 +202,17 @@ class BytecodeGenerator(ast.NodeVisitor):
         self.__add_instr('new', self.__get_dyobj_flag(['DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE']), 0)
         self.__add_instr('setctx', self.closure_map[name].closure_id, 0)
         self.__add_instr('stobj', self.__get_encoding_id(node.name), 0)
+
+    def visit_Return(self, node):
+        # TODO: need to handle return value.
+        self.__add_instr('rtrn', 0, 0)
+
+    def visit_Print(self, node):
+        # Currently only supports print one object.
+        if node.values:
+            self.visit(node.values[0])
+
+        self.__add_instr('print', 0, 0)
 
     def visit_Expr(self, node):
         self.visit(node.value)
@@ -252,7 +267,7 @@ class BytecodeGenerator(ast.NodeVisitor):
         self.__add_instr('invk', 0, 0)
 
     def visit_Num(self, node):
-        self.__add_instr('new', self.__get_dyobj_flag(['DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE']), 0)
+        self.__add_instr('new', 0, 0)
         self.__add_instr('uint32', node.n, 0)
         self.__add_instr('sethndl', 0, 0)
 
@@ -270,6 +285,11 @@ class BytecodeGenerator(ast.NodeVisitor):
         else:
             # TODO: Add support for other types of ctx of `Name` node.
             pass
+
+    def visit_Str(self, node):
+        self.__add_instr('new', 0, 0)
+        self.__add_instr('str', self.__get_encoding_id(node.s), 0)
+        self.__add_instr('sethndl', 0, 0)
 
     """ --------------------------- operator ------------------------------- """
 
@@ -412,7 +432,8 @@ class BytecodeGenerator(ast.NodeVisitor):
                 self.visit(default)
                 vector_length2 = len(self.__current_vector())
                 length_diff = vector_length2 - vector_length1
-                self.__current_vector()[vector_length1 - 1] = Instr('jmp', length_diff + 1, 0)
+                self.__current_vector()[vector_length1 - 1] = Instr(
+                    self.instr_str_to_code_map['jmp'], length_diff + 1, 0)
             else:
                 # This is an arg. It's handled in `visit_Name()`.
                 self.visit(arg)

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -152,7 +152,7 @@ class BytecodeGenerator(ast.NodeVisitor):
         )
 
     def __mingle_name(self, name):
-        # TDOO: Add support for actual name minglings.
+        # TDOO: [COREVM-177] Add support for name mingling in Python compiler
         return name
 
     def __get_encoding_id(self, name):
@@ -204,11 +204,11 @@ class BytecodeGenerator(ast.NodeVisitor):
         self.__add_instr('stobj', self.__get_encoding_id(node.name), 0)
 
     def visit_Return(self, node):
-        # TODO: need to handle return value.
+        # TODO: [COREVM-176] Support return value in Python
         self.__add_instr('rtrn', 0, 0)
 
     def visit_Print(self, node):
-        # Currently only supports print one object.
+        # TODO: [COREVM-178] Support for printing multiple values in Python
         if node.values:
             self.visit(node.values[0])
 

--- a/python/src/call.py
+++ b/python/src/call.py
@@ -1,7 +1,21 @@
-def do_math(*args):
-  1 + 1
+def hello_world_again(*args):
+  print 'Hello world again!'
 
-def hello_world(arg1, arg2, kwarg1=1+1, *args, **kwargs):
-  do_math(arg1)
+def introduction():
+  print 'My name is Will :-)'
+  # test explicit return should work.
+  return
 
-hello_world(1, 2, kwarg1=3)
+def hello_world(*args):
+  print 'Hello world!'
+  introduction()
+
+def main(arg1, arg2, *args, **kwargs):
+  print 'Hi'
+  hello_world(arg1)
+  hello_world_again()
+  hello_world(arg2)
+  print 'Bye'
+
+main(1, 2)
+print 'Done!'

--- a/src/runtime/frame.cc
+++ b/src/runtime/frame.cc
@@ -59,7 +59,7 @@ corevm::runtime::frame::eval_stack_size() const
 // -----------------------------------------------------------------------------
 
 corevm::runtime::instr_addr
-corevm::runtime::frame::get_start_addr() const
+corevm::runtime::frame::start_addr() const
 {
   return m_return_addr + 1;
 }
@@ -67,7 +67,7 @@ corevm::runtime::frame::get_start_addr() const
 // -----------------------------------------------------------------------------
 
 corevm::runtime::instr_addr
-corevm::runtime::frame::get_return_addr() const
+corevm::runtime::frame::return_addr() const
 {
   return m_return_addr;
 }

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -901,7 +901,7 @@ corevm::runtime::instr_handler_rtrn::execute(
 {
   corevm::runtime::frame& frame = process.top_frame();
 
-  corevm::runtime::instr_addr return_addr = frame.get_return_addr();
+  corevm::runtime::instr_addr return_addr = frame.return_addr();
 
   if (return_addr == corevm::runtime::NONESET_INSTR_ADDR)
   {
@@ -920,7 +920,7 @@ corevm::runtime::instr_handler_jmp::execute(
 {
   corevm::runtime::frame& frame = process.top_frame();
 
-  corevm::runtime::instr_addr starting_addr = frame.get_start_addr();
+  corevm::runtime::instr_addr starting_addr = frame.start_addr();
   corevm::runtime::instr_addr relative_addr = static_cast<corevm::runtime::instr_addr>(instr.oprd1);
 
   corevm::runtime::instr_addr addr = starting_addr + relative_addr;
@@ -945,7 +945,7 @@ corevm::runtime::instr_handler_jmpif::execute(
 {
   corevm::runtime::frame& frame = process.top_frame();
 
-  corevm::runtime::instr_addr starting_addr = frame.get_start_addr();
+  corevm::runtime::instr_addr starting_addr = frame.start_addr();
   corevm::runtime::instr_addr relative_addr = static_cast<corevm::runtime::instr_addr>(instr.oprd1);
 
   corevm::runtime::instr_addr addr = starting_addr + relative_addr;

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -60,6 +60,15 @@ std::ostream& operator<<(
   return ost;
 }
 
+// -----------------------------------------------------------------------------
+
+bool operator==(const instr& lhs, const instr& rhs)
+{
+  return lhs.code == rhs.code &&
+    lhs.oprd1 == rhs.oprd1 &&
+    lhs.oprd2 == rhs.oprd2;
+}
+
 
 } /* end namespace runtime */
 

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -220,13 +220,10 @@ corevm::runtime::process::pop_frame() throw(corevm::runtime::frame_not_found_err
   corevm::runtime::closure_id closure_id = frame.closure_ctx().closure_id;
   corevm::runtime::closure closure = compartment->get_closure_by_id(closure_id);
 
-  if (is_valid_pc())
-  {
-    auto begin_itr = m_instrs.begin() + pc();
-    auto end_itr = begin_itr + closure.vector.size();
+  auto begin_itr = m_instrs.begin() + pc();
+  auto end_itr = begin_itr + closure.vector.size();
 
-    m_instrs.erase(begin_itr, end_itr);
-  }
+  m_instrs.erase(begin_itr, end_itr);
 
   m_call_stack.pop_back();
 }

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -222,10 +222,10 @@ corevm::runtime::process::pop_frame() throw(corevm::runtime::frame_not_found_err
 
   if (is_valid_pc())
   {
-      auto begin_itr = m_instrs.begin() + pc();
-      auto end_itr = begin_itr + closure.vector.size();
+    auto begin_itr = m_instrs.begin() + pc();
+    auto end_itr = begin_itr + closure.vector.size();
 
-      m_instrs.erase(begin_itr, end_itr);
+    m_instrs.erase(begin_itr, end_itr);
   }
 
   m_call_stack.pop_back();
@@ -250,7 +250,8 @@ corevm::runtime::process::stack_size() const
 // -----------------------------------------------------------------------------
 
 const corevm::dyobj::dyobj_id&
-corevm::runtime::process::top_stack() throw(corevm::runtime::object_stack_empty_error)
+corevm::runtime::process::top_stack()
+  throw(corevm::runtime::object_stack_empty_error)
 {
   if (m_dyobj_stack.empty())
   {
@@ -271,7 +272,8 @@ corevm::runtime::process::push_stack(corevm::dyobj::dyobj_id& id)
 // -----------------------------------------------------------------------------
 
 const corevm::dyobj::dyobj_id
-corevm::runtime::process::pop_stack() throw(corevm::runtime::object_stack_empty_error)
+corevm::runtime::process::pop_stack()
+  throw(corevm::runtime::object_stack_empty_error)
 {
   if (m_dyobj_stack.empty())
   {
@@ -606,10 +608,14 @@ corevm::runtime::process::should_gc() const
       continue;
     }
 
-    corevm::runtime::gc_rule_meta::gc_bitfields bit = static_cast<corevm::runtime::gc_rule_meta::gc_bitfields>(i);
-    const corevm::runtime::gc_rule* gc_rule = corevm::runtime::gc_rule_meta::get_gc_rule(bit);
+    corevm::runtime::gc_rule_meta::gc_bitfields bit = \
+      static_cast<corevm::runtime::gc_rule_meta::gc_bitfields>(i);
 
-    if (gc_rule && gc_rule->should_gc(const_cast<const corevm::runtime::process&>(*this)))
+    const corevm::runtime::gc_rule* gc_rule = \
+      corevm::runtime::gc_rule_meta::get_gc_rule(bit);
+
+    if (gc_rule &&
+        gc_rule->should_gc(const_cast<const corevm::runtime::process&>(*this)))
     {
       return true;
     }

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -560,6 +560,9 @@ corevm::runtime::process::append_vector(const corevm::runtime::vector& vector)
 {
   // Inserts the vector at the very end of the instr array.
   // (This is different than `process::insert_vector`.
+  //
+  // NOTE: Please update `process_unittest::TestAppendVector` if the
+  // behavior here changes.
   std::copy(vector.begin(), vector.end(), std::back_inserter(m_instrs));
 }
 

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -572,6 +572,9 @@ void
 corevm::runtime::process::insert_vector(corevm::runtime::vector& vector)
 {
   // We want to insert the vector right after the current pc().
+  //
+  // NOTE: Please update `process_unittest::TestInsertVector` if the
+  // behavior here changes.
   m_instrs.insert(m_instrs.begin() + pc() + 1, vector.begin(), vector.end());
 }
 

--- a/tests/runtime/frame_unittest.cc
+++ b/tests/runtime/frame_unittest.cc
@@ -41,7 +41,7 @@ protected:
 TEST_F(frame_unittest, TestInitialization)
 {
   corevm::runtime::frame frame(m_closure_ctx);
-  ASSERT_EQ(-1, frame.get_return_addr());
+  ASSERT_EQ(-1, frame.return_addr());
 }
 
 // -----------------------------------------------------------------------------
@@ -49,11 +49,11 @@ TEST_F(frame_unittest, TestInitialization)
 TEST_F(frame_unittest, TestGetAndSetReturnAddr)
 {
   corevm::runtime::frame frame(m_closure_ctx);
-  ASSERT_EQ(-1, frame.get_return_addr());
+  ASSERT_EQ(-1, frame.return_addr());
 
   corevm::runtime::instr_addr expected_return_addr = 555;
   frame.set_return_addr(expected_return_addr);
-  ASSERT_EQ(expected_return_addr, frame.get_return_addr());
+  ASSERT_EQ(expected_return_addr, frame.return_addr());
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -1036,7 +1036,7 @@ TEST_F(instrs_control_instrs_test, TestInstrINVK)
 
   corevm::runtime::frame& actual_frame = m_process.top_frame();
 
-  ASSERT_EQ(m_process.pc(), actual_frame.get_return_addr());
+  ASSERT_EQ(m_process.pc(), actual_frame.return_addr());
 }
 
 // -----------------------------------------------------------------------------
@@ -1053,8 +1053,7 @@ TEST_F(instrs_control_instrs_test, TestInstrJMP)
   corevm::runtime::frame frame(m_ctx);
   m_process.push_frame(frame);
 
-  corevm::runtime::instr_addr current_addr = m_process.current_addr();
-  ASSERT_EQ(0, current_addr);
+  ASSERT_EQ(corevm::runtime::NONESET_INSTR_ADDR, m_process.pc());
 
   corevm::runtime::instr instr {
     .code=0,
@@ -1065,9 +1064,7 @@ TEST_F(instrs_control_instrs_test, TestInstrJMP)
   corevm::runtime::instr_handler_jmp handler;
   handler.execute(instr, m_process);
 
-  current_addr = m_process.current_addr();
-
-  ASSERT_EQ(8, current_addr);
+  ASSERT_EQ(8, m_process.pc());
 }
 
 // -----------------------------------------------------------------------------
@@ -1080,8 +1077,7 @@ TEST_F(instrs_control_instrs_test, TestInstrJMPIF)
   frame.push_eval_stack(hndl);
   m_process.push_frame(frame);
 
-  corevm::runtime::instr_addr current_addr = m_process.current_addr();
-  ASSERT_EQ(0, current_addr);
+  ASSERT_EQ(corevm::runtime::NONESET_INSTR_ADDR, m_process.pc());
 
   corevm::runtime::instr instr {
     .code=0,
@@ -1092,9 +1088,7 @@ TEST_F(instrs_control_instrs_test, TestInstrJMPIF)
   corevm::runtime::instr_handler_jmpif handler;
   handler.execute(instr, m_process);
 
-  current_addr = m_process.current_addr();
-
-  ASSERT_EQ(8, current_addr);
+  ASSERT_EQ(8, m_process.pc());
 }
 
 // -----------------------------------------------------------------------------
@@ -1107,8 +1101,7 @@ TEST_F(instrs_control_instrs_test, TestInstrJMPIF_OnFalseCondition)
   frame.push_eval_stack(hndl);
   m_process.push_frame(frame);
 
-  corevm::runtime::instr_addr current_addr = m_process.current_addr();
-  ASSERT_EQ(0, current_addr);
+  ASSERT_EQ(corevm::runtime::NONESET_INSTR_ADDR, m_process.pc());
 
   corevm::runtime::instr instr {
     .code=0,
@@ -1119,9 +1112,7 @@ TEST_F(instrs_control_instrs_test, TestInstrJMPIF_OnFalseCondition)
   corevm::runtime::instr_handler_jmpif handler;
   handler.execute(instr, m_process);
 
-  current_addr = m_process.current_addr();
-
-  ASSERT_EQ(0, current_addr);
+  ASSERT_EQ(corevm::runtime::NONESET_INSTR_ADDR, m_process.pc());
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -33,7 +33,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <sneaker/testing/_unittest.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <iterator>
 #include <sstream>
 
 
@@ -89,6 +91,38 @@ TEST_F(process_unittest, TestInstantiateWithParameters)
 
   ASSERT_LT(0, process.max_heap_size());
   ASSERT_LT(0, process.max_ntvhndl_pool_size());
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(process_unittest, TestAppendVector)
+{
+  // The process's vector is inaccessible to the outside world, so we need to
+  // simulate its implementation here.
+  corevm::runtime::vector target {
+    { .code=6, .oprd1=421, .oprd2=52 },
+    { .code=5, .oprd1=532, .oprd2=0  },
+    { .code=2, .oprd1=72,  .oprd2=0  },
+  };
+
+  corevm::runtime::vector dest {
+    { .code=36, .oprd1=41, .oprd2=81 },
+    { .code=37, .oprd1=27, .oprd2=0  },
+    { .code=83, .oprd1=93, .oprd2=0  },
+  };
+
+  std::copy(dest.begin(), dest.end(), std::back_inserter(target));
+
+  corevm::runtime::vector expected {
+    { .code=6, .oprd1=421, .oprd2=52 },
+    { .code=5, .oprd1=532, .oprd2=0  },
+    { .code=2, .oprd1=72,  .oprd2=0  },
+    { .code=36, .oprd1=41, .oprd2=81 },
+    { .code=37, .oprd1=27, .oprd2=0  },
+    { .code=83, .oprd1=93, .oprd2=0  },
+  };
+
+  ASSERT_EQ(true, expected == target);
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -194,7 +194,7 @@ TEST_F(process_unittest, TestPushAndPopFrames)
 
   process.insert_compartment(compartment);
 
-  // TODO: fix hard coded compartment_id.
+  // TODO: [COREVM-179] Make process::insert_compartment return the ID of the inserted compartment
   corevm::runtime::closure_ctx ctx1 {
     .compartment_id = 0,
     .closure_id = closure1.id,

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -105,13 +105,13 @@ TEST_F(process_unittest, TestAppendVector)
     { .code=2, .oprd1=72,  .oprd2=0  },
   };
 
-  corevm::runtime::vector dest {
+  corevm::runtime::vector src {
     { .code=36, .oprd1=41, .oprd2=81 },
     { .code=37, .oprd1=27, .oprd2=0  },
     { .code=83, .oprd1=93, .oprd2=0  },
   };
 
-  std::copy(dest.begin(), dest.end(), std::back_inserter(target));
+  std::copy(src.begin(), src.end(), std::back_inserter(target));
 
   corevm::runtime::vector expected {
     { .code=6, .oprd1=421, .oprd2=52 },
@@ -122,7 +122,55 @@ TEST_F(process_unittest, TestAppendVector)
     { .code=83, .oprd1=93, .oprd2=0  },
   };
 
-  ASSERT_EQ(true, expected == target);
+  ASSERT_EQ(expected, target);
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(process_unittest, TestInsertVector)
+{
+  // The process's vector is inaccessible to the outside world, so we need to
+  // simulate its implementation here.
+  corevm::runtime::vector target {
+    { .code=6,  .oprd1=421, .oprd2=52 },
+    { .code=5,  .oprd1=532, .oprd2=0  },
+    { .code=2,  .oprd1=72,  .oprd2=0  },
+    { .code=71, .oprd1=25,  .oprd2=0  },
+    { .code=18, .oprd1=51,  .oprd2=43 },
+    { .code=17, .oprd1=11,  .oprd2=99 },
+    { .code=33, .oprd1=88,  .oprd2=55 },
+    { .code=88, .oprd1=11,  .oprd2=91 },
+    { .code=17, .oprd1=71,  .oprd2=23 },
+    { .code=91, .oprd1=64,  .oprd2=67 },
+  };
+
+  corevm::runtime::vector src {
+    { .code=36, .oprd1=41,  .oprd2=81 },
+    { .code=37, .oprd1=27,  .oprd2=0  },
+    { .code=83, .oprd1=93,  .oprd2=0  },
+  };
+
+  int64_t fake_pc = 5;
+
+  target.insert(target.begin() + fake_pc + 1, src.begin(), src.end());
+
+  corevm::runtime::vector expected {
+    { .code=6,  .oprd1=421, .oprd2=52 },
+    { .code=5,  .oprd1=532, .oprd2=0  },
+    { .code=2,  .oprd1=72,  .oprd2=0  },
+    { .code=71, .oprd1=25,  .oprd2=0  },
+    { .code=18, .oprd1=51,  .oprd2=43 },
+    { .code=17, .oprd1=11,  .oprd2=99 },
+    { .code=36, .oprd1=41,  .oprd2=81 },
+    { .code=37, .oprd1=27,  .oprd2=0  },
+    { .code=83, .oprd1=93,  .oprd2=0  },
+    { .code=33, .oprd1=88,  .oprd2=55 },
+    { .code=88, .oprd1=11,  .oprd2=91 },
+    { .code=17, .oprd1=71,  .oprd2=23 },
+    { .code=91, .oprd1=64,  .oprd2=67 },
+  };
+
+  ASSERT_EQ(expected, target);
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -165,18 +165,53 @@ TEST_F(process_unittest, TestPushAndPopFrames)
   ASSERT_EQ(false, process.has_frame());
   ASSERT_EQ(0, process.call_stack_size());
 
-  corevm::runtime::closure_ctx ctx {
-    .compartment_id = corevm::runtime::NONESET_COMPARTMENT_ID,
-    .closure_id = corevm::runtime::NONESET_CLOSURE_ID
+  corevm::runtime::compartment compartment("./example.core");
+
+  corevm::runtime::vector vector {
+    { .code=6, .oprd1=421, .oprd2=523 },
+    { .code=5, .oprd1=532, .oprd2=0   },
+    { .code=2, .oprd1=72,  .oprd2=0   },
   };
 
-  corevm::runtime::frame frame1(ctx);
+  corevm::runtime::closure closure1 {
+    .id=1,
+    .parent_id=0,
+    .vector=vector
+  };
+
+  corevm::runtime::closure closure2 {
+    .id=2,
+    .parent_id=1,
+    .vector=vector
+  };
+
+  corevm::runtime::closure_table closure_table {
+    closure1,
+    closure2,
+  };
+
+  compartment.set_closure_table(closure_table);
+
+  process.insert_compartment(compartment);
+
+  // TODO: fix hard coded compartment_id.
+  corevm::runtime::closure_ctx ctx1 {
+    .compartment_id = 0,
+    .closure_id = closure1.id,
+  };
+
+  corevm::runtime::closure_ctx ctx2 {
+    .compartment_id = 0,
+    .closure_id = closure2.id,
+  };
+
+  corevm::runtime::frame frame1(ctx1);
   process.push_frame(frame1);
 
   ASSERT_EQ(true, process.has_frame());
   ASSERT_EQ(1, process.call_stack_size());
 
-  corevm::runtime::frame frame2(ctx);
+  corevm::runtime::frame frame2(ctx2);
   process.push_frame(frame2);
 
   ASSERT_EQ(true, process.has_frame());


### PR DESCRIPTION
Currently the way the program counter gets updated is incorrect when it gets changed by control instructions like `jmp`, and when frames are being popped out from the stack. Also, we need more robust check and error handling on the program counter throughout the lifespan of the process.

This patch encompasses several things:
* Made the process update its program counter when a frame gets popped off the call stack, and remove instructions associated with that frame on the process vector.
* Added a `print` instruction to print out the native type handle of the TOS object as a string.
* Added support for string literals in Python compiler.

**EGREGIOUS**: Prior to this patch, frame popping did not update the program counter correctly, thus function calls were not properly supported.

![function_call](https://cloud.githubusercontent.com/assets/554685/6543833/fff21150-c4e2-11e4-86f4-e3adfdcc8d6d.png)
Function calls in Python.