### PR TITLE
[COREVM-182] Implement emplace_frame

### DIFF
--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -112,6 +112,8 @@ public:
 
   void push_frame(corevm::runtime::frame&);
 
+  void emplace_frame(const corevm::runtime::closure_ctx&);
+
   void pop_frame() throw(corevm::runtime::frame_not_found_error);
 
   uint64_t stack_size() const;

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -880,8 +880,7 @@ corevm::runtime::instr_handler_pinvk::execute(
     throw corevm::runtime::closure_not_found_error(ctx.closure_id);
   }
 
-  corevm::runtime::frame frame(ctx);
-  process.push_frame(frame);
+  process.emplace_frame(ctx);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -238,6 +238,14 @@ corevm::runtime::process::push_frame(corevm::runtime::frame& frame)
 
 // -----------------------------------------------------------------------------
 
+void
+corevm::runtime::process::emplace_frame(const corevm::runtime::closure_ctx& ctx)
+{
+  m_call_stack.emplace_back(ctx);
+}
+
+// -----------------------------------------------------------------------------
+
 uint64_t
 corevm::runtime::process::stack_size() const
 {

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -309,6 +309,31 @@ TEST_F(process_unittest, TestPushAndPopFrames)
 
 // -----------------------------------------------------------------------------
 
+TEST_F(process_unittest, TestEmplaceFrame)
+{
+  corevm::runtime::process process;
+
+  ASSERT_EQ(false, process.has_frame());
+  ASSERT_EQ(0, process.call_stack_size());
+
+  corevm::runtime::closure_ctx ctx {
+    .compartment_id = 0,
+    .closure_id = 0,
+  };
+
+  process.emplace_frame(ctx);
+
+  ASSERT_EQ(true, process.has_frame());
+  ASSERT_EQ(1, process.call_stack_size());
+
+  auto& frame = process.top_frame();
+
+  ASSERT_EQ(ctx.compartment_id, frame.closure_ctx().compartment_id);
+  ASSERT_EQ(ctx.closure_id, frame.closure_ctx().closure_id);
+}
+
+// -----------------------------------------------------------------------------
+
 TEST_F(process_unittest, TestInsertAndAccessNativeTypeHandle)
 {
   corevm::runtime::process process;


### PR DESCRIPTION
Implement a member called `emplace_frame` in `runtime::process`, that takes an argument of the constructor of `runtime::frame`, and creates a frame on the call stack with that argument.