### PR TITLE
[COREVM-186] Add overloaded constructor to frame to also take return address

### DIFF
--- a/include/runtime/frame.h
+++ b/include/runtime/frame.h
@@ -53,7 +53,10 @@ namespace runtime {
 class frame
 {
 public:
-  explicit frame(corevm::runtime::closure_ctx);
+  explicit frame(const corevm::runtime::closure_ctx&);
+
+  frame(const corevm::runtime::closure_ctx&, corevm::runtime::instr_addr);
+
   ~frame();
 
   uint32_t eval_stack_size() const;

--- a/include/runtime/process.h
+++ b/include/runtime/process.h
@@ -116,6 +116,9 @@ public:
 
   void emplace_frame(const corevm::runtime::closure_ctx&);
 
+  void emplace_frame(
+    const corevm::runtime::closure_ctx&, corevm::runtime::instr_addr);
+
   void pop_frame() throw(corevm::runtime::frame_not_found_error);
 
   uint64_t stack_size() const;

--- a/src/runtime/frame.cc
+++ b/src/runtime/frame.cc
@@ -28,10 +28,27 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <cstdint>
 
 
-corevm::runtime::frame::frame(corevm::runtime::closure_ctx closure_ctx)
+// -----------------------------------------------------------------------------
+
+corevm::runtime::frame::frame(const corevm::runtime::closure_ctx& closure_ctx)
   :
   m_closure_ctx(closure_ctx),
   m_return_addr(corevm::runtime::NONESET_INSTR_ADDR),
+  m_visible_vars(),
+  m_invisible_vars(),
+  m_eval_stack()
+{
+  // Do nothing here.
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::runtime::frame::frame(
+  const corevm::runtime::closure_ctx& closure_ctx,
+  corevm::runtime::instr_addr return_addr)
+  :
+  m_closure_ctx(closure_ctx),
+  m_return_addr(return_addr),
   m_visible_vars(),
   m_invisible_vars(),
   m_eval_stack()

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -896,12 +896,7 @@ corevm::runtime::instr_handler_invk::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
   corevm::runtime::closure_ctx ctx = process.top_invocation_ctx().ctx();
-
-  process.emplace_frame(ctx);
-
-  corevm::runtime::frame& frame = process.top_frame();
-
-  frame.set_return_addr(process.pc());
+  process.emplace_frame(ctx, process.pc());
 
   corevm::runtime::compartment* compartment = nullptr;
   process.get_compartment(ctx.compartment_id, &compartment);

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -251,6 +251,15 @@ corevm::runtime::process::emplace_frame(const corevm::runtime::closure_ctx& ctx)
 
 // -----------------------------------------------------------------------------
 
+void
+corevm::runtime::process::emplace_frame(
+  const corevm::runtime::closure_ctx& ctx, corevm::runtime::instr_addr return_addr)
+{
+  m_call_stack.emplace_back(ctx, return_addr);
+}
+
+// -----------------------------------------------------------------------------
+
 uint64_t
 corevm::runtime::process::stack_size() const
 {
@@ -498,9 +507,7 @@ corevm::runtime::process::pre_start()
 
     append_vector(closure.vector);
 
-    corevm::runtime::frame frame(ctx);
-    frame.set_return_addr(m_pc);
-    push_frame(frame);
+    emplace_frame(ctx, m_pc);
 
     emplace_invocation_ctx(ctx);
 

--- a/tests/runtime/frame_unittest.cc
+++ b/tests/runtime/frame_unittest.cc
@@ -41,7 +41,17 @@ protected:
 TEST_F(frame_unittest, TestInitialization)
 {
   corevm::runtime::frame frame(m_closure_ctx);
-  ASSERT_EQ(-1, frame.return_addr());
+  ASSERT_EQ(corevm::runtime::NONESET_INSTR_ADDR, frame.return_addr());
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(frame_unittest, TestInitializationWithReturnAddr)
+{
+  corevm::runtime::instr_addr return_addr = 100;
+  corevm::runtime::frame frame(m_closure_ctx, return_addr);
+
+  ASSERT_EQ(return_addr, frame.return_addr());
 }
 
 // -----------------------------------------------------------------------------
@@ -49,7 +59,7 @@ TEST_F(frame_unittest, TestInitialization)
 TEST_F(frame_unittest, TestGetAndSetReturnAddr)
 {
   corevm::runtime::frame frame(m_closure_ctx);
-  ASSERT_EQ(-1, frame.return_addr());
+  ASSERT_EQ(corevm::runtime::NONESET_INSTR_ADDR, frame.return_addr());
 
   corevm::runtime::instr_addr expected_return_addr = 555;
   frame.set_return_addr(expected_return_addr);


### PR DESCRIPTION
Adding a second constructor to `corevm::runtime::frame` that also takes the return address.