### PR TITLE
[COREVM-187] Implement True and False values in Python

### DIFF
--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -171,6 +171,15 @@ enum instr_enum : uint32_t
    */
   SETCTX,
 
+  /**
+   * <cldobj, oprd1, oprd2>
+   * Conditionally loads an object associated with the variable key value
+   * represented by either oprd1 or oprd2, by evaluating the boolean equivalent
+   * of the object on top of the evaluation stack. Loads `oprd1` if the value
+   * evaluates to true, `oprd2` otherwise.
+   */
+  CLDOBJ,
+
   /* ------------------------ Control instructions -------------------------- */
 
   /**
@@ -1125,6 +1134,14 @@ public:
 // -----------------------------------------------------------------------------
 
 class instr_handler_setctx : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_cldobj : public instr_handler
 {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -174,9 +174,9 @@ enum instr_enum : uint32_t
   /**
    * <cldobj, oprd1, oprd2>
    * Conditionally loads an object associated with the variable key value
-   * represented by either oprd1 or oprd2, by evaluating the boolean equivalent
-   * of the object on top of the evaluation stack. Loads `oprd1` if the value
-   * evaluates to true, `oprd2` otherwise.
+   * represented by either `oprd1` or `oprd2`, by evaluating the boolean
+   * equivalent of the object on top of the evaluation stack. Loads `oprd1`
+   * if the value evaluates to true, `oprd2` otherwise.
    */
   CLDOBJ,
 

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -163,6 +163,17 @@ class CodeTransformer(ast.NodeVisitor):
             rhs=self.visit(node.right)
         )
 
+    def visit_Compare(self, node):
+        # Note: Only supports one comparison now.
+        base_str = '{indentation}{left} {op} {comparator}'.format(
+          indentation=self.__indentation(),
+          left=self.visit(node.left),
+          op=self.visit(node.ops[0]),
+          comparator=self.visit(node.comparators[0])
+        )
+
+        return base_str
+
     def visit_Call(self, node):
         base_str = '{indentation}__call({caller}'
 
@@ -230,7 +241,7 @@ class CodeTransformer(ast.NodeVisitor):
     def visit_Not(self, node):
         return 'not'
 
-    """ ---------------------------- unaryop ------------------------------- """
+    """ ----------------------------- cmpop -------------------------------- """
 
     def visit_Is(self, node):
         return 'is'

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -57,7 +57,7 @@ class CodeTransformer(ast.NodeVisitor):
     """ ------------------------------ mod --------------------------------- """
 
     def visit_Module(self, node):
-        return ''.join([self.visit(stmt) for stmt in node.body])
+        return '\n'.join([self.visit(stmt) for stmt in node.body])
 
     """ ----------------------------- stmt --------------------------------- """
 
@@ -104,6 +104,15 @@ class CodeTransformer(ast.NodeVisitor):
             base_str += (' ' + self.visit(node.value))
 
         base_str += '\n'
+
+        return base_str
+
+    def visit_Assign(self, node):
+        base_str = '{indentation}{exprs} = {value}\n'.format(
+          indentation=self.__indentation(),
+          exprs=', '.join([self.visit(expr) for expr in node.exprs]),
+          value=self.visit(node.value)
+        )
 
         return base_str
 

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -261,6 +261,10 @@ class BytecodeGenerator(ast.NodeVisitor):
             self.visit(node.value)
         self.__add_instr('rtrn', 0, 0)
 
+    def visit_Assign(self, node):
+        self.visit(node.value)
+        self.visit(node.targets[0])
+
     def visit_Print(self, node):
         # TODO: [COREVM-178] Support for printing multiple values in Python
         if node.values:
@@ -333,6 +337,8 @@ class BytecodeGenerator(ast.NodeVisitor):
             # Note: here we only want to handle args. kwargs are handled
             # differently in `visit_arguments`.
             self.__add_instr('getarg', 0, 0)
+            self.__add_instr('stobj', self.__get_encoding_id(name), 0)
+        elif isinstance(node.ctx, ast.Store):
             self.__add_instr('stobj', self.__get_encoding_id(name), 0)
         else:
             # TODO: Add support for other types of ctx of `Name` node.
@@ -448,8 +454,7 @@ class BytecodeGenerator(ast.NodeVisitor):
 
     def visit_Is(self, node):
         self.__add_instr('objeq', 0, 0)
-        self.__add_instr('new', 0, 0)
-        self.__add_instr('sethndl', 0, 0)
+        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_IsNot(self, node):
         self.__add_instr('objneq', 0, 0)
@@ -584,6 +589,11 @@ def main():
             builtin_tree = ast.parse(fd.read())
 
         generator.visit(builtin_tree)
+
+        with open('python/src/bool.py', 'r') as fd:
+            bool_tree = ast.parse(fd.read())
+
+        generator.visit(bool_tree)
 
         with open('python/src/int.py', 'r') as fd:
             int_tree = ast.parse(fd.read())

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -436,21 +436,27 @@ class BytecodeGenerator(ast.NodeVisitor):
 
     def visit_Eq(self, node):
         self.__add_instr('eq', 0, 0)
+        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_NotEq(self, node):
         self.__add_instr('neq', 0, 0)
+        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_Lt(self, node):
         self.__add_instr('lt', 0, 0)
+        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_LtE(self, node):
         self.__add_instr('lte', 0, 0)
+        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_Gt(self, node):
         self.__add_instr('gt', 0, 0)
+        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_GtE(self, node):
         self.__add_instr('gte', 0, 0)
+        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_Is(self, node):
         self.__add_instr('objeq', 0, 0)
@@ -458,6 +464,7 @@ class BytecodeGenerator(ast.NodeVisitor):
 
     def visit_IsNot(self, node):
         self.__add_instr('objneq', 0, 0)
+        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_In(self, node):
         pass

--- a/python/src/__builtin__.py
+++ b/python/src/__builtin__.py
@@ -13,6 +13,7 @@ class object:
         ### END VECTOR ###
         """
 
+
 def __call(caller, arg):
     # Need to support *args and **kwargs.
     if caller.__class__ is type:

--- a/python/src/bool.py
+++ b/python/src/bool.py
@@ -1,0 +1,37 @@
+class bool(object):
+
+    def __init__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [2bool, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+### True
+"""
+### BEGIN VECTOR ###
+[new, 0, 0]
+[ldobj, bool, 0]
+[setattr, __class__, 0]
+[bool, 1, 0]
+[sethndl, 0, 0]
+[stobj, True, 0]
+### END VECTOR ###
+"""
+
+### False
+"""
+### BEGIN VECTOR ###
+[new, 0, 0]
+[ldobj, bool, 0]
+[setattr, __class__, 0]
+[bool, 0, 0]
+[sethndl, 0, 0]
+[stobj, False, 0]
+### END VECTOR ###
+"""

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -1,0 +1,2 @@
+True
+False

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -1,2 +1,3 @@
 True
 False
+True is False


### PR DESCRIPTION
This patch implements the `bool` type, as well as the global `True` and `False` values in Python.

The `bool` type implemented right now is bare bone, which means that it does not support all the methods on the type as of yet, same goes for the `int` type. Those will be supported in the future.

Also implemented a `cldobj` instruction, which conditionally loads either the key represented by the first or second operand, by evaluating the boolean equivalent of the element on top of the eval stack. This makes it possible to load either `True` or `False` depending on the last boolean value evaluated.