### PR TITLE
[COREVM-188] Implement str type in Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 # Tests
 *.test
 
+# Python
+*.pyc
+
 # Outputs
 info.json
 *.tmp.py

--- a/python/bootstrap_tests.py
+++ b/python/bootstrap_tests.py
@@ -34,6 +34,9 @@ import optparse
 import os
 import subprocess
 
+from colors import colors
+from stdout_comparator import StdoutComparator
+
 
 PYTHON = 'python'
 PYTHON_TESTS_DIR = './python/tests/'
@@ -43,17 +46,6 @@ INFO_FILE = './info.json'
 COREVM = './coreVM'
 INTERMEDIATE_EXTENSION = '.tmp.py'
 BYTECODE_EXTENSION = '.core'
-
-
-class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
 
 
 def code_transformer_input_to_output_path(path):
@@ -92,6 +84,10 @@ def corevm_cmdl_args(path):
     return [COREVM, '--input', compiler_input_to_output_path(path)]
 
 
+def python_cmdl_args(path):
+    return [PYTHON, path]
+
+
 def run(options):
     inputs = glob.glob(PYTHON_TESTS_DIR + '*.py')
     real_inputs = []
@@ -116,7 +112,7 @@ def run(options):
         retcode = subprocess.call(args)
 
         if retcode != 0:
-            info += (bcolors.WARNING + ' [FAILED]' + bcolors.ENDC)
+            info += (colors.WARNING + ' [FAILED]' + colors.ENDC)
             print info
             continue
 
@@ -126,7 +122,7 @@ def run(options):
 
         retcode = subprocess.call(args)
         if retcode != 0:
-            info += (bcolors.WARNING + ' [FAILED]' + bcolors.ENDC)
+            info += (colors.WARNING + ' [FAILED]' + colors.ENDC)
             print info
             continue
 
@@ -134,12 +130,12 @@ def run(options):
         if options.debug_mode:
             print subprocess.list2cmdline(args)
 
-        retcode = subprocess.call(args)
+        retcode = StdoutComparator(args, python_cmdl_args(path)).run()
 
         if retcode == 0:
-            info += (bcolors.OKGREEN + ' [SUCCESS]' + bcolors.ENDC)
+            info += (colors.OKGREEN + ' [SUCCESS]' + colors.ENDC)
         else:
-            info += (bcolors.FAIL + ' [FAILED]' + bcolors.ENDC)
+            info += (colors.FAIL + ' [FAILED]' + colors.ENDC)
 
         print info
 

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -217,7 +217,7 @@ class CodeTransformer(ast.NodeVisitor):
         return node.id
 
     def visit_Str(self, node):
-        return '\'{s}\''.format(s=node.s)
+        return '__call(str, \"%s\")' % str(node.s)
 
     """ --------------------------- operator ------------------------------- """
 

--- a/python/colors.py
+++ b/python/colors.py
@@ -1,0 +1,9 @@
+class colors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -114,8 +114,6 @@ class BytecodeGenerator(ast.NodeVisitor):
 
     default_closure_name = '__main__'
 
-    in_class_def = False
-
     def __init__(self, options):
         self.output_file = options.output_file
         self.debug_mode = options.debug_mode
@@ -138,7 +136,7 @@ class BytecodeGenerator(ast.NodeVisitor):
         }
 
         # states
-        self.under_class_def = False
+        self.current_class_name = ''
 
     def finalize(self):
         structured_bytecode = {
@@ -182,7 +180,7 @@ class BytecodeGenerator(ast.NodeVisitor):
 
     def __mingle_name(self, name):
         # TDOO: [COREVM-177] Add support for name mingling in Python compiler
-        return name
+        return self.current_class_name + '.' + name
 
     def __get_encoding_id(self, name):
         if name not in self.encoding_map:
@@ -233,12 +231,12 @@ class BytecodeGenerator(ast.NodeVisitor):
         self.__add_instr('ldobj', self.__get_encoding_id('object'), 0)
         self.__add_instr('setattr', self.__get_encoding_id('__class__'), 0)
 
-        if not self.in_class_def:
+        if not self.current_class_name:
             self.__add_instr('stobj', self.__get_encoding_id(node.name), 0)
 
     def visit_ClassDef(self, node):
         # Step in.
-        self.in_class_def = True
+        self.current_class_name = self.current_class_name + '::' + node.name
 
         self.__add_instr('new', self.__get_dyobj_flag(['DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE']), 0)
         self.__add_instr('stobj', self.__get_encoding_id(node.name), 0)
@@ -253,7 +251,7 @@ class BytecodeGenerator(ast.NodeVisitor):
                 self.__add_instr('setattr', self.__get_encoding_id(stmt.name), 0)
 
         # Step out.
-        self.in_class_def = False
+        self.current_class_name = '::'.join(self.current_class_name.split('::')[:-1])
 
     def visit_Return(self, node):
         # TODO: [COREVM-176] Support return value in Python
@@ -607,6 +605,10 @@ def main():
 
         generator.visit(int_tree)
 
+        with open('python/src/str.py', 'r') as fd:
+            str_tree = ast.parse(fd.read())
+
+        generator.visit(str_tree)
         with open(options.input_file, 'r') as fd:
             tree = ast.parse(fd.read())
 

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -138,6 +138,12 @@ class BytecodeGenerator(ast.NodeVisitor):
         # states
         self.current_class_name = ''
 
+    def read_from_source(self, path):
+        with open(path, 'r') as fd:
+            tree = ast.parse(fd.read())
+
+        self.visit(tree)
+
     def finalize(self):
         structured_bytecode = {
             'format': self.format,
@@ -590,29 +596,13 @@ def main():
     try:
         generator = BytecodeGenerator(options)
 
-        with open('python/src/__builtin__.py', 'r') as fd:
-            builtin_tree = ast.parse(fd.read())
+        generator.read_from_source('python/src/__builtin__.py')
+        generator.read_from_source('python/src/bool.py')
+        generator.read_from_source('python/src/int.py')
+        generator.read_from_source('python/src/str.py')
 
-        generator.visit(builtin_tree)
+        generator.read_from_source(options.input_file)
 
-        with open('python/src/bool.py', 'r') as fd:
-            bool_tree = ast.parse(fd.read())
-
-        generator.visit(bool_tree)
-
-        with open('python/src/int.py', 'r') as fd:
-            int_tree = ast.parse(fd.read())
-
-        generator.visit(int_tree)
-
-        with open('python/src/str.py', 'r') as fd:
-            str_tree = ast.parse(fd.read())
-
-        generator.visit(str_tree)
-        with open(options.input_file, 'r') as fd:
-            tree = ast.parse(fd.read())
-
-        generator.visit(tree)
         generator.finalize()
     except Exception as ex:
         sys.stderr.write('Failed to compile %s\n' % options.input_file)

--- a/python/src/str.py
+++ b/python/src/str.py
@@ -1,0 +1,13 @@
+class str(object):
+
+    def __init__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [2str, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """

--- a/python/stdout_comparator.py
+++ b/python/stdout_comparator.py
@@ -1,0 +1,37 @@
+import subprocess
+
+from colors import colors
+
+
+class StdoutComparator(object):
+
+    def __init__(self, lhs_args, rhs_args):
+        self.lhs_args = lhs_args
+        self.rhs_args = rhs_args
+
+    def run(self):
+        try:
+            lhs_output = subprocess.check_output(self.lhs_args)
+        except subprocess.CalledProcessError:
+            return -1
+
+        try:
+            rhs_output = subprocess.check_output(self.rhs_args)
+        except subprocess.CalledProcessError:
+            return -1
+
+        if lhs_output == rhs_output:
+            return 0
+
+        output = colors.HEADER + 'Difference in output:\n'
+        output += colors.FAIL
+        output += lhs_output
+        output += '\n'
+        output += colors.OKBLUE
+        output += rhs_output
+        output += colors.ENDC
+        output += '\n'
+
+        print output
+
+        return -1

--- a/python/tests/str.py
+++ b/python/tests/str.py
@@ -1,0 +1,1 @@
+str("Hello world")

--- a/python/tests/str.py
+++ b/python/tests/str.py
@@ -1,1 +1,2 @@
-str("Hello world")
+print str("Hello world")
+print str(str("Hi again!!!"))


### PR DESCRIPTION
This patch implements the bare bone `str` type in Python. However, it currently does not support all the instance methods. Also, conversion between `str` type and other types is not supported in this patch.

Other changes:
* Fixed a bug of incorrectly associating class methods of the same name that belong to different classes.
* Implemented  a `StdoutComparator` that compares outputs between coreVM and Python sent to stdout.