### PR TITLE
[COREVM-189] Add support for Python instance methods

### DIFF
--- a/include/dyobj/dynamic_object.h
+++ b/include/dyobj/dynamic_object.h
@@ -391,7 +391,7 @@ corevm::dyobj::dynamic_object<dynamic_object_manager>::putattr(
   corevm::dyobj::dynamic_object<dynamic_object_manager>::attr_key_type attr_key,
   corevm::dyobj::dynamic_object<dynamic_object_manager>::dyobj_id_type obj_id) noexcept
 {
-  m_attrs.insert({attr_key, obj_id});
+  m_attrs[attr_key] = obj_id;
 }
 
 // -----------------------------------------------------------------------------

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -180,6 +180,22 @@ enum instr_enum : uint32_t
    */
   CLDOBJ,
 
+  /**
+   * <setattrs, _, _>
+   * Converts the native type handle on top of the eval stack to a native map,
+   * and use its key-value pairs as attribute name-value pairs to set on the
+   * object on the top of the stack.
+   */
+  SETATTRS,
+
+  /**
+   * <rsetattrs, attr, _>
+   * Reverse set attributes. Set the object on top of stack as the attribute
+   * values onto the objects pointed to as values in the native map equivalent
+   * on top of the eval stack.
+   */
+  RSETATTRS,
+
   /* ------------------------ Control instructions -------------------------- */
 
   /**
@@ -889,6 +905,14 @@ enum instr_enum : uint32_t
   MAPPUT,
 
   /**
+   * <mapset, key, _>
+   * Converts the top element on the eval stack to a native map, and insert a
+   * key-value pair into it, with the key represented as the first operand,
+   * and the value as the object on top of the stack.
+   */
+  MAPSET,
+
+  /**
    * <mapers, _, _>
    * Pops the top element on the eval stack, and performs the "map erase"
    * operation.
@@ -1142,6 +1166,22 @@ public:
 // -----------------------------------------------------------------------------
 
 class instr_handler_cldobj : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_setattrs : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_rsetattrs : public instr_handler
 {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
@@ -2018,6 +2058,14 @@ public:
 // -----------------------------------------------------------------------------
 
 class instr_handler_mapput : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_mapset : public instr_handler
 {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);

--- a/python/bootstrap_tests.py
+++ b/python/bootstrap_tests.py
@@ -90,14 +90,10 @@ def python_cmdl_args(path):
 
 def run(options):
     inputs = glob.glob(PYTHON_TESTS_DIR + '*.py')
-    real_inputs = []
+    real_inputs = [path for path in inputs if not path.endswith(INTERMEDIATE_EXTENSION)]
 
     print 'Bootstrapping Python tests...'
-    print 'Testing using the following %d input file(s):' % len(inputs)
-    for path in inputs:
-        if not path.endswith(INTERMEDIATE_EXTENSION):
-            real_inputs.append(path)
-            print path
+    print 'Testing using the following %d input file(s):' % len(real_inputs)
 
     # Bring blank line.
     print

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -109,9 +109,9 @@ class CodeTransformer(ast.NodeVisitor):
 
     def visit_Assign(self, node):
         base_str = '{indentation}{targets} = {value}\n'.format(
-          indentation=self.__indentation(),
-          targets=', '.join([self.visit(target) for target in node.targets]),
-          value=self.visit(node.value)
+            indentation=self.__indentation(),
+            targets=', '.join([self.visit(target) for target in node.targets]),
+            value=self.visit(node.value)
         )
 
         return base_str
@@ -217,8 +217,8 @@ class CodeTransformer(ast.NodeVisitor):
 
     def visit_Attribute(self, node):
         return '{expr}.{attr}'.format(
-          expr=self.visit(node.value),
-          attr=str(node.attr)
+            expr=self.visit(node.value),
+            attr=str(node.attr)
         )
 
     def visit_Name(self, node):

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -72,7 +72,7 @@ class CodeTransformer(ast.NodeVisitor):
 
         self.__indent()
 
-        base_str += ''.join([self.visit(stmt) for stmt in node.body])
+        base_str += '\n'.join([self.visit(stmt) for stmt in node.body])
         base_str = base_str.replace(', )', ')')
         base_str += '\n'
 
@@ -108,9 +108,9 @@ class CodeTransformer(ast.NodeVisitor):
         return base_str
 
     def visit_Assign(self, node):
-        base_str = '{indentation}{exprs} = {value}\n'.format(
+        base_str = '{indentation}{targets} = {value}\n'.format(
           indentation=self.__indentation(),
-          exprs=', '.join([self.visit(expr) for expr in node.exprs]),
+          targets=', '.join([self.visit(target) for target in node.targets]),
           value=self.visit(node.value)
         )
 
@@ -151,6 +151,9 @@ class CodeTransformer(ast.NodeVisitor):
 
     def visit_Expr(self, node):
         return self.visit(node.value)
+
+    def visit_Pass(self, node):
+        return '{indentation}pass'.format(indentation=self.__indentation())
 
     """ ----------------------------- expr --------------------------------- """
 
@@ -206,12 +209,18 @@ class CodeTransformer(ast.NodeVisitor):
         base_str += ')'
 
         base_str = base_str.replace(', )', ')')
-        base_str += '\n'
+        #base_str += '\n'
 
         return base_str
 
     def visit_Num(self, node):
         return '__call(int, %s)' % str(node.n)
+
+    def visit_Attribute(self, node):
+        return '{expr}.{attr}'.format(
+          expr=self.visit(node.value),
+          attr=str(node.attr)
+        )
 
     def visit_Name(self, node):
         return node.id

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -209,7 +209,6 @@ class CodeTransformer(ast.NodeVisitor):
         base_str += ')'
 
         base_str = base_str.replace(', )', ')')
-        #base_str += '\n'
 
         return base_str
 

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -57,7 +57,6 @@ class VectorString(object):
         return vector
 
 
-
 class Instr(object):
 
     def __init__(self, code, oprd1, oprd2):

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -257,9 +257,11 @@ class BytecodeGenerator(ast.NodeVisitor):
             if isinstance(stmt, ast.FunctionDef):
                 self.__add_instr('gethndl', 0, 0)
                 self.visit(stmt)
+                self.__add_instr('ldobj', self.__get_encoding_id('MethodType'), 0)
+                self.__add_instr('setattr', self.__get_encoding_id('__class__'), 0)
                 self.__add_instr('mapset', self.__get_encoding_id(stmt.name), 0)
-                self.__add_instr('sethndl', 0, 0)
                 self.__add_instr('setattr', self.__get_encoding_id(stmt.name), 0)
+                self.__add_instr('sethndl', 0, 0)
 
         # Step out.
         self.current_class_name = '::'.join(self.current_class_name.split('::')[:-1])

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -245,6 +245,8 @@ class BytecodeGenerator(ast.NodeVisitor):
         self.current_class_name = self.current_class_name + '::' + node.name
 
         self.__add_instr('new', self.__get_dyobj_flag(['DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE']), 0)
+        self.__add_instr('map', 0, 0)
+        self.__add_instr('sethndl', 0, 0)
         self.__add_instr('stobj', self.__get_encoding_id(node.name), 0)
         self.__add_instr('ldobj', self.__get_encoding_id(node.name), 0)
         self.__add_instr('ldobj', self.__get_encoding_id('type'), 0)
@@ -253,7 +255,10 @@ class BytecodeGenerator(ast.NodeVisitor):
         for stmt in node.body:
             # TODO|NOTE: currently only supports functions.
             if isinstance(stmt, ast.FunctionDef):
+                self.__add_instr('gethndl', 0, 0)
                 self.visit(stmt)
+                self.__add_instr('mapset', self.__get_encoding_id(stmt.name), 0)
+                self.__add_instr('sethndl', 0, 0)
                 self.__add_instr('setattr', self.__get_encoding_id(stmt.name), 0)
 
         # Step out.
@@ -364,7 +369,7 @@ class BytecodeGenerator(ast.NodeVisitor):
                 raw_oprd1 = raw_oprd1.strip()
                 raw_oprd2 = raw_oprd2.strip()
 
-                if raw_code in ('ldobj', 'stobj', 'setattr', 'getattr', 'putkwarg', 'str'):
+                if raw_code in ('ldobj', 'stobj', 'setattr', 'getattr', 'putkwarg', 'rsetattrs', 'str'):
                     oprd1 = self.__get_encoding_id(raw_oprd1)
                 else:
                     oprd1 = int(raw_oprd1)

--- a/python/src/__builtin__.py
+++ b/python/src/__builtin__.py
@@ -9,6 +9,9 @@ class object:
         ### BEGIN VECTOR ###
         [new, 0, 0]
         [ldobj, cls, 0]
+        [gethndl, 0, 0]
+        [setattrs, 0, 0]
+        [rsetattrs, im_self, 0]
         [setattr, __class__, 0]
         ### END VECTOR ###
         """

--- a/python/src/__builtin__.py
+++ b/python/src/__builtin__.py
@@ -2,6 +2,10 @@ class type:
     pass
 
 
+class MethodType:
+    pass
+
+
 class object:
 
     def __new__(cls, arg):
@@ -10,16 +14,19 @@ class object:
         [new, 0, 0]
         [ldobj, cls, 0]
         [gethndl, 0, 0]
+        [setattr, __class__, 0]
         [setattrs, 0, 0]
         [rsetattrs, im_self, 0]
-        [setattr, __class__, 0]
         ### END VECTOR ###
         """
-
 
 def __call(caller, arg):
     # Need to support *args and **kwargs.
     if caller.__class__ is type:
-        return caller.__init__(object.__new__(caller, arg), arg)
+        obj = object.__new__(caller, arg)
+        caller.__init__(obj, arg)
+        return obj
+    elif caller.__class__ is MethodType:
+        return caller(caller.im_self, arg)
     else:
         return caller(arg)

--- a/python/tests/class.py
+++ b/python/tests/class.py
@@ -1,0 +1,11 @@
+class MyObject(object):
+
+    def __init__(self, arg):
+        pass
+
+    def run(self, arg):
+        print arg
+
+
+o = MyObject(1)
+o.run('Hello world')

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -102,7 +102,7 @@ corevm::runtime::instr_handler_meta::instr_info_map {
   { corevm::runtime::instr_enum::OBJNEQ,    { .num_oprd=0, .str="objneq",    .handler=std::make_shared<corevm::runtime::instr_handler_objneq>()    } },
   { corevm::runtime::instr_enum::SETCTX,    { .num_oprd=1, .str="setctx",    .handler=std::make_shared<corevm::runtime::instr_handler_setctx>()    } },
   { corevm::runtime::instr_enum::CLDOBJ,    { .num_oprd=2, .str="cldobj",    .handler=std::make_shared<corevm::runtime::instr_handler_cldobj>()    } },
-  { corevm::runtime::instr_enum::SETATTRS,   { .num_oprd=0, .str="setattrs",  .handler=std::make_shared<corevm::runtime::instr_handler_setattrs>()  } },
+  { corevm::runtime::instr_enum::SETATTRS,  { .num_oprd=0, .str="setattrs",  .handler=std::make_shared<corevm::runtime::instr_handler_setattrs>()  } },
   { corevm::runtime::instr_enum::RSETATTRS, { .num_oprd=1, .str="rsetattrs", .handler=std::make_shared<corevm::runtime::instr_handler_rsetattrs>() } },
 
   /* -------------------------- Control instructions ------------------------ */

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -102,6 +102,8 @@ corevm::runtime::instr_handler_meta::instr_info_map {
   { corevm::runtime::instr_enum::OBJNEQ,    { .num_oprd=0, .str="objneq",    .handler=std::make_shared<corevm::runtime::instr_handler_objneq>()    } },
   { corevm::runtime::instr_enum::SETCTX,    { .num_oprd=1, .str="setctx",    .handler=std::make_shared<corevm::runtime::instr_handler_setctx>()    } },
   { corevm::runtime::instr_enum::CLDOBJ,    { .num_oprd=2, .str="cldobj",    .handler=std::make_shared<corevm::runtime::instr_handler_cldobj>()    } },
+  { corevm::runtime::instr_enum::SETATTRS,   { .num_oprd=0, .str="setattrs",  .handler=std::make_shared<corevm::runtime::instr_handler_setattrs>()  } },
+  { corevm::runtime::instr_enum::RSETATTRS, { .num_oprd=1, .str="rsetattrs", .handler=std::make_shared<corevm::runtime::instr_handler_rsetattrs>() } },
 
   /* -------------------------- Control instructions ------------------------ */
 
@@ -234,6 +236,7 @@ corevm::runtime::instr_handler_meta::instr_info_map {
   { corevm::runtime::instr_enum::MAPEMP,    { .num_oprd=0, .str="mapemp",    .handler=std::make_shared<corevm::runtime::instr_handler_mapemp>()    } },
   { corevm::runtime::instr_enum::MAPAT,     { .num_oprd=0, .str="mapat",     .handler=std::make_shared<corevm::runtime::instr_handler_mapat>()     } },
   { corevm::runtime::instr_enum::MAPPUT,    { .num_oprd=0, .str="mapput",    .handler=std::make_shared<corevm::runtime::instr_handler_mapput>()    } },
+  { corevm::runtime::instr_enum::MAPSET,    { .num_oprd=1, .str="mapset",    .handler=std::make_shared<corevm::runtime::instr_handler_mapset>()    } },
   { corevm::runtime::instr_enum::MAPERS,    { .num_oprd=0, .str="mapers",    .handler=std::make_shared<corevm::runtime::instr_handler_mapers>()    } },
   { corevm::runtime::instr_enum::MAPCLR,    { .num_oprd=0, .str="mapclr",    .handler=std::make_shared<corevm::runtime::instr_handler_mapclr>()    } },
   { corevm::runtime::instr_enum::MAPSWP,    { .num_oprd=0, .str="mapswp",    .handler=std::make_shared<corevm::runtime::instr_handler_mapswp>()    } },
@@ -918,6 +921,75 @@ corevm::runtime::instr_handler_cldobj::execute(
   auto id = frame_ptr->get_visible_var(key);
 
   process.push_stack(id);
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::instr_handler_setattrs::execute(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  corevm::dyobj::dyobj_id id = process.top_stack();
+  auto& obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
+
+  corevm::runtime::frame& frame = process.top_frame();
+
+  corevm::types::native_type_handle hndl = frame.pop_eval_stack();
+  corevm::types::native_type_handle res;
+
+  corevm::types::interface_to_map(hndl, res);
+
+  corevm::types::native_map map = corevm::types::get_value_from_handle<
+    corevm::types::native_map>(res);
+
+  for (auto itr = map.begin(); itr != map.end(); ++itr)
+  {
+    corevm::dyobj::attr_key attr_key = static_cast<corevm::dyobj::attr_key>(itr->first);
+    corevm::dyobj::dyobj_id attr_id = static_cast<corevm::dyobj::dyobj_id>(itr->second);
+
+    auto &attr_obj = corevm::runtime::process::adapter(process).help_get_dyobj(attr_id);
+    attr_obj.manager().on_setattr();
+    obj.putattr(attr_key, attr_id);
+  }
+
+  res = map;
+
+  frame.push_eval_stack(res);
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::instr_handler_rsetattrs::execute(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  corevm::dyobj::attr_key attr_key = static_cast<corevm::dyobj::attr_key>(instr.oprd1);
+
+  corevm::dyobj::dyobj_id attr_id = process.top_stack();
+  auto& attr_obj = corevm::runtime::process::adapter(process).help_get_dyobj(attr_id);
+
+  corevm::runtime::frame& frame = process.top_frame();
+
+  corevm::types::native_type_handle hndl = frame.pop_eval_stack();
+  corevm::types::native_type_handle res;
+
+  corevm::types::interface_to_map(hndl, res);
+
+  corevm::types::native_map map = corevm::types::get_value_from_handle<
+    corevm::types::native_map>(res);
+
+  for (auto itr = map.begin(); itr != map.end(); ++itr)
+  {
+    corevm::dyobj::dyobj_id id = static_cast<corevm::dyobj::dyobj_id>(itr->second);
+
+    auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
+    attr_obj.manager().on_setattr();
+    obj.putattr(attr_key, attr_id);
+  }
+
+  res = map;
+
+  frame.push_eval_stack(res);
 }
 
 // -----------------------------------------------------------------------------
@@ -2360,6 +2432,34 @@ corevm::runtime::instr_handler_mapput::execute(
     process,
     corevm::types::interface_map_put
   );
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::instr_handler_mapset::execute(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  corevm::types::native_map_key_type key = static_cast<
+    corevm::types::native_map_key_type>(instr.oprd1);
+
+  corevm::dyobj::dyobj_id id = process.top_stack();
+
+  corevm::runtime::frame& frame = process.top_frame();
+
+  corevm::types::native_type_handle hndl = frame.pop_eval_stack();
+  corevm::types::native_type_handle res;
+
+  corevm::types::interface_to_map(hndl, res);
+
+  corevm::types::native_map map = corevm::types::get_value_from_handle<
+    corevm::types::native_map>(res);
+
+  map[key] = id;
+
+  res = map;
+
+  frame.push_eval_stack(res);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
This patch adds support for invocations of instance methods in Python, which essentially checks if the caller is an a type of instance method, and if it is, pass in its associated owner (through the `im_self` attribute on the method) as the first argument in the invocation.

To be able to associate an instance of a class with its methods defined in its associated class, as well as setting itself as the value of the `im_self` attribute on all these methods, three instructions were added to facilitate this: `SETATTRS`, `RSETATTRS`, and `MAPSET`.

Also fixed a bug which corrected that calling `__init__` on an object instance should only return `None` in Python.