### PR TITLE
[COREVM-190] Create repr instruction

### DIFF
--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -697,7 +697,8 @@ enum instr_enum : uint32_t
 
   /**
    * <repr, _, _>
-   * Converts the element on top of the eval stack to its string representation.
+   * Computes the string equivalent representation of the element on top of the
+   * eval stack, and push it on top of the stack.
    */
   REPR,
 

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -695,6 +695,12 @@ enum instr_enum : uint32_t
    */
   TRUTHY,
 
+  /**
+   * <repr, _, _>
+   * Converts the element on top of the eval stack to its string representation.
+   */
+  REPR,
+
   /* ---------------------- String type instructions ------------------------ */
 
   /**
@@ -1808,6 +1814,14 @@ public:
 // -----------------------------------------------------------------------------
 
 class instr_handler_truthy : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_repr : public instr_handler
 {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);

--- a/include/types/interfaces.h
+++ b/include/types/interfaces.h
@@ -253,6 +253,11 @@ void interface_compute_truthy_value(
 
 // -----------------------------------------------------------------------------
 
+void interface_compute_repr_value(
+  native_type_handle& operand, native_type_handle& result);
+
+// -----------------------------------------------------------------------------
+
 
 /* -------------------------- STRING OPERATIONS ----------------------------- */
 

--- a/include/types/native_type_handle.h
+++ b/include/types/native_type_handle.h
@@ -57,6 +57,19 @@ using native_type_handle = typename boost::variant<
 // -----------------------------------------------------------------------------
 
 template<class op>
+class native_type_pure_visitor : public boost::static_visitor<native_type_handle>
+{
+public:
+  template<typename T>
+  native_type_handle operator()(const T& operand) const
+  {
+    return op().template operator()<T>(operand);
+  }
+};
+
+// -----------------------------------------------------------------------------
+
+template<class op>
 class native_type_unary_visitor : public boost::static_visitor<native_type_handle>
 {
 public:
@@ -117,6 +130,10 @@ public:
     return static_cast<T>(handle.value);
   }
 };
+
+// -----------------------------------------------------------------------------
+
+class native_type_repr_visitor : public native_type_pure_visitor<repr> {};
 
 // -----------------------------------------------------------------------------
 

--- a/include/types/operators.h
+++ b/include/types/operators.h
@@ -27,6 +27,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "types.h"
 
 #include <cmath>
+#include <iomanip>
+#include <sstream>
 
 
 namespace corevm {
@@ -206,6 +208,44 @@ typename corevm::types::boolean::value_type
 corevm::types::truthy::operator()<corevm::types::boolean>(const corevm::types::map& handle)
 {
   return !handle.value.empty();
+}
+
+// -----------------------------------------------------------------------------
+
+class repr: public unary_op
+{
+public:
+  template<typename R, typename T>
+  typename corevm::types::string::value_type operator()(const T& handle)
+  {
+    std::stringstream ss;
+    ss << std::setprecision(8) << handle.value;
+
+    typename corevm::types::string::value_type value =
+      static_cast<typename corevm::types::string::value_type>(ss.str());
+
+    return value;
+  }
+};
+
+// -----------------------------------------------------------------------------
+
+template<>
+inline
+typename corevm::types::string::value_type
+corevm::types::repr::operator()<corevm::types::array>(const corevm::types::array& handle)
+{
+  return static_cast<corevm::types::string::value_type>("<array>");
+}
+
+// -----------------------------------------------------------------------------
+
+template<>
+inline
+typename corevm::types::string::value_type
+corevm::types::repr::operator()<corevm::types::map>(const corevm::types::map& handle)
+{
+  return static_cast<corevm::types::string::value_type>("<map>");
 }
 
 // -----------------------------------------------------------------------------

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -198,6 +198,7 @@ corevm::runtime::instr_handler_meta::instr_info_map {
   /* ----------------- Native type manipulation instructions ---------------- */
 
   { corevm::runtime::instr_enum::TRUTHY,    { .num_oprd=0, .str="truthy",    .handler=std::make_shared<corevm::runtime::instr_handler_truthy>()     } },
+  { corevm::runtime::instr_enum::REPR,      { .num_oprd=0, .str="repr",      .handler=std::make_shared<corevm::runtime::instr_handler_repr>()      } },
 
   /* --------------------- String type instructions ------------------------- */
 
@@ -2055,6 +2056,23 @@ corevm::runtime::instr_handler_truthy::execute(
     process,
     corevm::types::interface_compute_truthy_value
   );
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::instr_handler_repr::execute(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  corevm::runtime::frame& frame = process.top_frame();
+
+  corevm::types::native_type_handle oprd = frame.pop_eval_stack();
+  corevm::types::native_type_handle result;
+
+  corevm::types::interface_compute_repr_value(oprd, result);
+
+  frame.push_eval_stack(oprd);
+  frame.push_eval_stack(result);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/types/interfaces.cc
+++ b/src/types/interfaces.cc
@@ -423,6 +423,14 @@ void corevm::types::interface_compute_truthy_value(
 
 // -----------------------------------------------------------------------------
 
+void corevm::types::interface_compute_repr_value(
+  native_type_handle& operand, native_type_handle& result)
+{
+  __interface_apply_unary_operator<native_type_repr_visitor>(operand, result);
+}
+
+// -----------------------------------------------------------------------------
+
 
 /* -------------------------- STRING OPERATIONS ----------------------------- */
 

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -2050,6 +2050,132 @@ TEST_F(instrs_native_type_conversion_instrs_test, TestInstr2MAP)
 
 // -----------------------------------------------------------------------------
 
+class instrs_native_type_manipulation_instrs_test : public instrs_native_types_instrs_test
+{
+protected:
+  virtual void SetUp()
+  {
+    m_process.emplace_frame(m_ctx);
+  }
+
+  template<typename InstrHandlerCls, typename TargetNativeType>
+  void execute_instr_and_assert_result(typename TargetNativeType::value_type& expected_value)
+  {
+    InstrHandlerCls instr_handler;
+
+    corevm::runtime::instr instr { .code=0, .oprd1=0, .oprd2=0 };
+
+    instr_handler.execute(instr, m_process);
+
+    corevm::runtime::frame& frame = m_process.top_frame();
+
+    corevm::types::native_type_handle result_handle = frame.pop_eval_stack();
+
+    auto actual_value = corevm::types::get_value_from_handle<
+      typename TargetNativeType::value_type>(result_handle);
+
+    ASSERT_EQ(expected_value, actual_value);
+  }
+};
+
+// -----------------------------------------------------------------------------
+
+TEST_F(instrs_native_type_manipulation_instrs_test, TestInstrREPR_01)
+{
+  auto& frame = m_process.top_frame();
+
+  corevm::types::native_type_handle hndl = corevm::types::uint32(5);
+
+  frame.push_eval_stack(hndl);
+
+  corevm::types::native_string expected_value("5");
+
+  execute_instr_and_assert_result<
+    corevm::runtime::instr_handler_repr, corevm::types::string>(expected_value);
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(instrs_native_type_manipulation_instrs_test, TestInstrREPR_02)
+{
+  auto& frame = m_process.top_frame();
+
+  corevm::types::native_type_handle hndl = corevm::types::decimal(3.141592);
+
+  frame.push_eval_stack(hndl);
+
+  corevm::types::native_string expected_value("3.141592");
+
+  execute_instr_and_assert_result<
+    corevm::runtime::instr_handler_repr, corevm::types::string>(expected_value);
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(instrs_native_type_manipulation_instrs_test, TestInstrREPR_03)
+{
+  auto& frame = m_process.top_frame();
+
+  corevm::types::native_type_handle hndl = corevm::types::boolean(false);
+
+  frame.push_eval_stack(hndl);
+
+  corevm::types::native_string expected_value("0");
+
+  execute_instr_and_assert_result<
+    corevm::runtime::instr_handler_repr, corevm::types::string>(expected_value);
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(instrs_native_type_manipulation_instrs_test, TestInstrREPR_04)
+{
+  auto& frame = m_process.top_frame();
+
+  corevm::types::native_type_handle hndl = corevm::types::string("Hello world!");
+
+  frame.push_eval_stack(hndl);
+
+  corevm::types::native_string expected_value("Hello world!");
+
+  execute_instr_and_assert_result<
+    corevm::runtime::instr_handler_repr, corevm::types::string>(expected_value);
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(instrs_native_type_manipulation_instrs_test, TestInstrREPR_05)
+{
+  auto& frame = m_process.top_frame();
+
+  corevm::types::native_type_handle hndl = corevm::types::array({1, 2, 3});
+
+  frame.push_eval_stack(hndl);
+
+  corevm::types::native_string expected_value("<array>");
+
+  execute_instr_and_assert_result<
+    corevm::runtime::instr_handler_repr, corevm::types::string>(expected_value);
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(instrs_native_type_manipulation_instrs_test, TestInstrREPR_06)
+{
+  auto& frame = m_process.top_frame();
+
+  corevm::types::native_type_handle hndl = corevm::types::map({ { 1 , 2 } });
+
+  frame.push_eval_stack(hndl);
+
+  corevm::types::native_string expected_value("<map>");
+
+  execute_instr_and_assert_result<
+    corevm::runtime::instr_handler_repr, corevm::types::string>(expected_value);
+}
+
+// -----------------------------------------------------------------------------
+
 class instrs_native_type_complex_instrs_test : public instrs_native_types_instrs_test
 {
 public:


### PR DESCRIPTION
Implement instruction `repr`, which creates a string representation of all native types. This will be useful for type conversions in Python (e.g. converting an instance of `int` to its string representation).