### PR TITLE
[COREVM-191] Add support for Python int to str conversion

### DIFF
--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -120,6 +120,9 @@ class CodeTransformer(ast.NodeVisitor):
         base_str = '{indentation}print'.format(indentation=self.__indentation())
 
         if node.values:
+            # NOTE: Passing a value of `1` as the second argument as it is just
+            # a placeholder for the second parameter right now, until support
+            # for *args and **kwargs are in place.
             base_str += (' ' + '__call(' + self.visit(node.values[0]) + '.__str__' + ', 1)')
 
         base_str += '\n'

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -120,8 +120,7 @@ class CodeTransformer(ast.NodeVisitor):
         base_str = '{indentation}print'.format(indentation=self.__indentation())
 
         if node.values:
-            values_str = '.'.join([self.visit(value) for value in node.values])
-            base_str += (' ' + values_str)
+            base_str += (' ' + '__call(' + self.visit(node.values[0]) + '.__str__' + ', 1)')
 
         base_str += '\n'
 

--- a/python/src/bool.py
+++ b/python/src/bool.py
@@ -12,6 +12,12 @@ class bool(object):
         ### END VECTOR ###
         """
 
+    def __str__(self, arg_):
+        if self:
+            return __call(str, 'True')
+        else:
+            return __call(str, 'False')
+
 ### True
 """
 ### BEGIN VECTOR ###
@@ -23,6 +29,8 @@ class bool(object):
 [stobj, True, 0]
 ### END VECTOR ###
 """
+True = __call(bool, 1)
+
 
 ### False
 """
@@ -35,3 +43,5 @@ class bool(object):
 [stobj, False, 0]
 ### END VECTOR ###
 """
+
+False = __call(bool, 0)

--- a/python/src/int.py
+++ b/python/src/int.py
@@ -11,6 +11,21 @@ class int(object):
         ### END VECTOR ###
         """
 
+    def __str__(self, arg_):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [repr, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, value, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+        str_obj = __call(str, value)
+        return str_obj
+
     def __add__(self, value):
         """
         ### BEGIN VECTOR ###

--- a/python/src/str.py
+++ b/python/src/str.py
@@ -11,3 +11,6 @@ class str(object):
         [sethndl, 0, 0]
         ### END VECTOR ###
         """
+
+    def __str__(self, arg_):
+        return self

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -1,3 +1,5 @@
+# NOTE: This is actually working, but incorrectly.
+# TODO: [COREVM-192] Fix instance method owner association
 print True
 print False
 print bool(1)

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -1,3 +1,5 @@
-True
-False
+print True
+print False
+print bool(1)
+print bool(0)
 True is False

--- a/python/tests/int.py
+++ b/python/tests/int.py
@@ -1,1 +1,1 @@
-int(1)
+print int(1)


### PR DESCRIPTION
Add support in the Python compiler to make instances of type `int` to be able to convert to type `str`.