### PR TITLE
[COREVM-192] Fix instance method owner association

### DIFF
--- a/include/dyobj/dynamic_object.h
+++ b/include/dyobj/dynamic_object.h
@@ -456,6 +456,7 @@ void
 corevm::dyobj::dynamic_object<dynamic_object_manager>::copy_from(
   const dynamic_object<dynamic_object_manager>& src)
 {
+  // NOTE: Need to be careful about what fields are being copied here.
   m_flags = src.m_flags;
   m_attrs = src.m_attrs;
   m_ntvhndl_key = src.m_ntvhndl_key;

--- a/include/dyobj/dynamic_object.h
+++ b/include/dyobj/dynamic_object.h
@@ -111,6 +111,8 @@ public:
   template<typename Function>
   void iterate(Function) noexcept;
 
+  void copy_from(const dynamic_object<dynamic_object_manager>&);
+
 private:
   void check_flag_bit(char) const throw(corevm::dyobj::invalid_flag_bit_error);
 
@@ -445,6 +447,19 @@ corevm::dyobj::dynamic_object<dynamic_object_manager>::iterate(Function func) no
       );
     }
   );
+}
+
+// -----------------------------------------------------------------------------
+
+template <class dynamic_object_manager>
+void
+corevm::dyobj::dynamic_object<dynamic_object_manager>::copy_from(
+  const dynamic_object<dynamic_object_manager>& src)
+{
+  m_flags = src.m_flags;
+  m_attrs = src.m_attrs;
+  m_ntvhndl_key = src.m_ntvhndl_key;
+  m_closure_ctx = src.m_closure_ctx;
 }
 
 // -----------------------------------------------------------------------------

--- a/include/runtime/instr.h
+++ b/include/runtime/instr.h
@@ -181,10 +181,13 @@ enum instr_enum : uint32_t
   CLDOBJ,
 
   /**
-   * <setattrs, _, _>
+   * <setattrs, #, #>
    * Converts the native type handle on top of the eval stack to a native map,
    * and use its key-value pairs as attribute name-value pairs to set on the
-   * object on the top of the stack.
+   * object on the top of the stack. The first operand is a boolean value
+   * specifying whether each mapped object should be cloned before set on the
+   * target object. The second operand is a boolean value indicating if
+   * the native map values should be overriden with the cloned object IDs.
    */
   SETATTRS,
 

--- a/python/src/__builtin__.py
+++ b/python/src/__builtin__.py
@@ -15,7 +15,7 @@ class object:
         [ldobj, cls, 0]
         [gethndl, 0, 0]
         [setattr, __class__, 0]
-        [setattrs, 0, 0]
+        [setattrs, 1, 1]
         [rsetattrs, im_self, 0]
         ### END VECTOR ###
         """

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -1,5 +1,3 @@
-# NOTE: This is actually working, but incorrectly.
-# TODO: [COREVM-192] Fix instance method owner association
 print True
 print False
 print bool(1)

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -102,7 +102,7 @@ corevm::runtime::instr_handler_meta::instr_info_map {
   { corevm::runtime::instr_enum::OBJNEQ,    { .num_oprd=0, .str="objneq",    .handler=std::make_shared<corevm::runtime::instr_handler_objneq>()    } },
   { corevm::runtime::instr_enum::SETCTX,    { .num_oprd=1, .str="setctx",    .handler=std::make_shared<corevm::runtime::instr_handler_setctx>()    } },
   { corevm::runtime::instr_enum::CLDOBJ,    { .num_oprd=2, .str="cldobj",    .handler=std::make_shared<corevm::runtime::instr_handler_cldobj>()    } },
-  { corevm::runtime::instr_enum::SETATTRS,  { .num_oprd=0, .str="setattrs",  .handler=std::make_shared<corevm::runtime::instr_handler_setattrs>()  } },
+  { corevm::runtime::instr_enum::SETATTRS,  { .num_oprd=2, .str="setattrs",  .handler=std::make_shared<corevm::runtime::instr_handler_setattrs>()  } },
   { corevm::runtime::instr_enum::RSETATTRS, { .num_oprd=1, .str="rsetattrs", .handler=std::make_shared<corevm::runtime::instr_handler_rsetattrs>() } },
 
   /* -------------------------- Control instructions ------------------------ */

--- a/tests/dyobj/dynamic_object_unittest.cc
+++ b/tests/dyobj/dynamic_object_unittest.cc
@@ -234,6 +234,51 @@ TEST_F(dynamic_object_unittest, TestSetAndGetClosureCtx)
 
 // -----------------------------------------------------------------------------
 
+TEST_F(dynamic_object_unittest, TestCopyFrom)
+{
+  dynamic_object_type obj;
+
+  corevm::runtime::closure_ctx expected_ctx {
+    .compartment_id = 123,
+    .closure_id = 456
+  };
+
+  obj.set_closure_ctx(expected_ctx);
+
+  corevm::dyobj::attr_key key1 = 123;
+  corevm::dyobj::attr_key key2 = 456;
+  corevm::dyobj::attr_key key3 = 789;
+
+  corevm::dyobj::dyobj_id attr_id1 = 321;
+  corevm::dyobj::dyobj_id attr_id2 = 654;
+  corevm::dyobj::dyobj_id attr_id3 = 987;
+
+  obj.putattr(key1, attr_id1);
+  obj.putattr(key2, attr_id2);
+  obj.putattr(key3, attr_id3);
+
+  char flag1 = corevm::dyobj::flags::DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE;
+  char flag2 = corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE;
+
+  obj.set_flag(flag1);
+  obj.set_flag(flag2);
+
+  dynamic_object_type dst;
+
+  dst.copy_from(obj);
+
+  ASSERT_EQ(obj.closure_ctx().compartment_id, dst.closure_ctx().compartment_id);
+  ASSERT_EQ(obj.closure_ctx().closure_id, dst.closure_ctx().closure_id);
+
+  ASSERT_EQ(obj.getattr(key1), dst.getattr(key1));
+  ASSERT_EQ(obj.getattr(key2), dst.getattr(key2));
+  ASSERT_EQ(obj.getattr(key3), dst.getattr(key3));
+
+  ASSERT_EQ(obj.flags(), dst.flags());
+}
+
+// -----------------------------------------------------------------------------
+
 TEST_F(dynamic_object_unittest, TestEquality)
 {
   dynamic_object_type obj;


### PR DESCRIPTION
Currently instance methods are single instance objects that are associated to one instance of an owner. If another object of the same class is instantiated, the instance methods of the previous object (previous owner) no longer reference it through the `im_self` attribute. Technically, instance methods should have the relationship of one instance per owner.

The fix here is to make dynamic objects able to copy a set of attributes from others through the `copy_from()` member, and to make the instruction `setattrs` able to copy the methods on a class first before setting them on an instance of the class, thus achieving to one-to-one relation for instance methods and instances of a class.