### PR TITLE
[COREVM-194] Add support for arithmetic operations for basic types in Python

### DIFF
--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -160,7 +160,7 @@ class CodeTransformer(ast.NodeVisitor):
     """ ----------------------------- expr --------------------------------- """
 
     def visit_BinOp(self, node):
-        base_str = '{lhs}.{func}({lhs}, {rhs})'
+        base_str = '__call({lhs}.{func}, {rhs})'
 
         return base_str.format(
             lhs=self.visit(node.left),

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -426,19 +426,19 @@ class BytecodeGenerator(ast.NodeVisitor):
         self.__add_instr('sethndl', 0, 0)
 
     def visit_Add(self, node):
-        self.__add_binary_operator_instr('add')
+        raise NotImplemented
 
     def visit_Sub(self, node):
-        self.__add_binary_operator_instr('sub')
+        raise NotImplemented
 
     def visit_Mult(self, node):
-        self.__add_binary_operator_instr('mul')
+        raise NotImplemented
 
     def visit_Div(self, node):
-        self.__add_binary_operator_instr('div')
+        raise NotImplemented
 
     def visit_Mod(self, node):
-        self.__add_binary_operator_instr('mod')
+        raise NotImplemented
 
     def visit_Pow(self, node):
         self.__add_binary_operator_instr('pow')

--- a/python/src/bool.py
+++ b/python/src/bool.py
@@ -18,6 +18,93 @@ class bool(object):
         else:
             return __call(str, 'False')
 
+
+    def __add__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [add, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __sub__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [sub, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __mul__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [mul, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __div__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [div, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __mod__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [mod, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+
 ### True
 """
 ### BEGIN VECTOR ###

--- a/python/src/float.py
+++ b/python/src/float.py
@@ -25,3 +25,88 @@ class float(object):
         ### END VECTOR ###
         """
         return __call(str, value)
+
+    def __add__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [add, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(float, res_)
+
+    def __sub__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [sub, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(float, res_)
+
+    def __mul__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [mul, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(float, res_)
+
+    def __div__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [div, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(float, res_)
+
+    def __mod__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [mod, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(float, res_)

--- a/python/src/int.py
+++ b/python/src/int.py
@@ -34,6 +34,80 @@ class int(object):
         [gethndl, 0, 0]
         [pop, 0, 0]
         [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [add, 0, 0]
+        [new, 0, 0]
         [sethndl, 0, 0]
+        [stobj, res_, 0]
         ### END VECTOR ###
         """
+        return __call(int, res_)
+
+    def __sub__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [sub, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __mul__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [mul, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __div__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [div, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __mod__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [mod, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -3,3 +3,13 @@ print False
 print bool(1)
 print bool(0)
 True is False
+
+# NOTE: Python prints arithmetic operations on bools as `1`s and `0`s, but we
+# actually print them as `True` and `False`, so can't do stdout comparision.
+# ( Kinda sad :'( )
+# But the results were verified as correct.
+# print True + False
+# print True - False
+# print True * False
+# print False / True
+# print False % True

--- a/python/tests/float.py
+++ b/python/tests/float.py
@@ -1,2 +1,8 @@
 print 5824.674626
 print float(3.141592)
+print 1.329431 + 5.953167
+print 99.838301 - 99.000123
+print 123.456 * 987.654
+print 999.666333 / 3.00
+# TODO: [COREVM-196] Modulus operator for float type inaccurate
+#print 100.000001 % 33.000000

--- a/python/tests/int.py
+++ b/python/tests/int.py
@@ -1,2 +1,7 @@
 print 1234567890
 print int(987654321)
+print 1 + 2
+print 987654321 - 123456789
+print 567 * 654
+print 101 / 11
+print 110 % 33


### PR DESCRIPTION
Add support for basic arithmetic operations in Python for the basic types. For now just focus on the `int`, `float`, and `bool` types.