### PR TITLE
[COREVM-199] Code cleanup

### DIFF
--- a/include/runtime/frame.h
+++ b/include/runtime/frame.h
@@ -61,8 +61,6 @@ public:
 
   uint32_t eval_stack_size() const;
 
-  corevm::runtime::instr_addr start_addr() const;
-
   corevm::runtime::instr_addr return_addr() const;
 
   void set_return_addr(const corevm::runtime::instr_addr);

--- a/include/runtime/invocation_ctx.h
+++ b/include/runtime/invocation_ctx.h
@@ -45,9 +45,9 @@ typedef std::unordered_map<corevm::runtime::variable_key, corevm::dyobj::dyobj_i
 class invocation_ctx
 {
 public:
-  explicit invocation_ctx(const closure_ctx&);
+  explicit invocation_ctx(const corevm::runtime::closure_ctx&);
 
-  const closure_ctx& ctx() const;
+  const closure_ctx& closure_ctx() const;
 
   const param_list_type& params_list() const;
 
@@ -73,7 +73,7 @@ public:
   std::list<corevm::runtime::variable_key> param_value_pair_keys() const;
 
 private:
-  corevm::runtime::closure_ctx m_ctx;
+  corevm::runtime::closure_ctx m_closure_ctx;
   param_list_type m_params_list;
   param_value_map_type m_param_value_map;
 };

--- a/src/frontend/utils.cc
+++ b/src/frontend/utils.cc
@@ -108,7 +108,7 @@ corevm::frontend::get_v0_1_instr_code_schema_definition()
   const std::string def(
     str(boost::format(unformatted_def) % ss.str().c_str()));
 
-  return def;
+  return std::move(def);
 }
 
 // -----------------------------------------------------------------------------
@@ -133,7 +133,7 @@ corevm::frontend::get_v0_1_instr_oprd_schema_definition()
     )
   );
 
-  return def;
+  return std::move(def);
 }
 
 // -----------------------------------------------------------------------------
@@ -166,7 +166,7 @@ corevm::frontend::get_v0_1_vector_schema_definition()
     )
   );
 
-  return def;
+  return std::move(def);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/runtime/frame.cc
+++ b/src/runtime/frame.cc
@@ -74,14 +74,6 @@ corevm::runtime::frame::eval_stack_size() const
 // -----------------------------------------------------------------------------
 
 corevm::runtime::instr_addr
-corevm::runtime::frame::start_addr() const
-{
-  return m_return_addr + 1;
-}
-
-// -----------------------------------------------------------------------------
-
-corevm::runtime::instr_addr
 corevm::runtime::frame::return_addr() const
 {
   return m_return_addr;

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -1034,7 +1034,7 @@ void
 corevm::runtime::instr_handler_invk::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::runtime::closure_ctx ctx = process.top_invocation_ctx().ctx();
+  corevm::runtime::closure_ctx ctx = process.top_invocation_ctx().closure_ctx();
   process.emplace_frame(ctx, process.pc());
 
   corevm::runtime::compartment* compartment = nullptr;

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -1071,7 +1071,7 @@ corevm::runtime::instr_handler_jmp::execute(
 {
   corevm::runtime::frame& frame = process.top_frame();
 
-  corevm::runtime::instr_addr starting_addr = frame.start_addr();
+  corevm::runtime::instr_addr starting_addr = process.pc();
   corevm::runtime::instr_addr relative_addr = static_cast<corevm::runtime::instr_addr>(instr.oprd1);
 
   corevm::runtime::instr_addr addr = starting_addr + relative_addr;
@@ -1096,7 +1096,7 @@ corevm::runtime::instr_handler_jmpif::execute(
 {
   corevm::runtime::frame& frame = process.top_frame();
 
-  corevm::runtime::instr_addr starting_addr = process.pc(); //frame.start_addr();
+  corevm::runtime::instr_addr starting_addr = process.pc();
   corevm::runtime::instr_addr relative_addr = static_cast<corevm::runtime::instr_addr>(instr.oprd1);
 
   corevm::runtime::instr_addr addr = starting_addr + relative_addr;

--- a/src/runtime/invocation_ctx.cc
+++ b/src/runtime/invocation_ctx.cc
@@ -29,9 +29,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // -----------------------------------------------------------------------------
 
-corevm::runtime::invocation_ctx::invocation_ctx(const closure_ctx& ctx)
+corevm::runtime::invocation_ctx::invocation_ctx(
+  const corevm::runtime::closure_ctx& ctx)
   :
-  m_ctx(ctx),
+  m_closure_ctx(ctx),
   m_params_list(),
   m_param_value_map()
 {
@@ -40,9 +41,9 @@ corevm::runtime::invocation_ctx::invocation_ctx(const closure_ctx& ctx)
 // -----------------------------------------------------------------------------
 
 const corevm::runtime::closure_ctx&
-corevm::runtime::invocation_ctx::ctx() const
+corevm::runtime::invocation_ctx::closure_ctx() const
 {
-  return m_ctx;
+  return m_closure_ctx;
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -1101,7 +1101,10 @@ TEST_F(instrs_runtime_instrs_test, TestInstrDEBUG)
 {
   corevm::runtime::instr instr { .code=0, .oprd1=0, .oprd2=0 };
   corevm::runtime::instr_handler_debug handler;
+
   handler.execute(instr, m_process);
+
+  std::cout << "(output above expected)" << std::endl;
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -1160,7 +1160,7 @@ TEST_F(instrs_control_instrs_test, TestInstrPINVK)
 
   corevm::runtime::invocation_ctx& invk_ctx = m_process.top_invocation_ctx();
 
-  corevm::runtime::closure_ctx ctx = invk_ctx.ctx();
+  corevm::runtime::closure_ctx ctx = invk_ctx.closure_ctx();
 
   ASSERT_TRUE(m_ctx == ctx);
 }

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -1233,7 +1233,7 @@ TEST_F(instrs_control_instrs_test, TestInstrJMP)
   corevm::runtime::instr_handler_jmp handler;
   handler.execute(instr, m_process);
 
-  ASSERT_EQ(8, m_process.pc());
+  ASSERT_EQ(7, m_process.pc());
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/runtime/invocation_ctx_unittest.cc
+++ b/tests/runtime/invocation_ctx_unittest.cc
@@ -47,7 +47,7 @@ protected:
 TEST_F(invocation_ctx_unittest, TestInitialization)
 {
   corevm::runtime::invocation_ctx invk_ctx(m_ctx);
-  ASSERT_TRUE(m_ctx == invk_ctx.ctx());
+  ASSERT_TRUE(m_ctx == invk_ctx.closure_ctx());
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Some code cleanups:

* Removed `frame::start_addr()`.
* Renamed `invocation_ctx::ctx()` to `invocation_ctx::closure_ctx()` for more clarity.
* Print "output above expected" for `instrs_runtime_instrs_test.TestInstrDEBUG`.
* Make sure of `std::move` at various places.