### PR TITLE
[COREVM-207] Fix duplicate native handle creation issue

### DIFF
--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -764,9 +764,18 @@ corevm::runtime::instr_handler_sethndl::execute(
   corevm::dyobj::dyobj_id id = process.top_stack();
   auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
 
-  corevm::dyobj::ntvhndl_key ntvhndl_key = process.insert_ntvhndl(hndl);
+  corevm::dyobj::ntvhndl_key key = obj.ntvhndl_key();
 
-  obj.set_ntvhndl_key(ntvhndl_key);
+  if (key == corevm::dyobj::NONESET_NTVHNDL_KEY)
+  {
+    corevm::dyobj::ntvhndl_key new_ntvhndl_key = process.insert_ntvhndl(hndl);
+
+    obj.set_ntvhndl_key(new_ntvhndl_key);
+  }
+  else
+  {
+    process.get_ntvhndl(key) = hndl;
+  }
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Currently, when setting or modifying the content of a native type handle associated with an object, `gethndl` and `sethndl` are called before and after a set of instructions for doing the actual work, respectively. However, `sethndl` actually creates a new handle by copying the existing one. Therefore, duplicate handles are created every time these two instructions are getting called. Or in other words, there are dangling handles left in the native types pool, being unreferenced, and therefore will never be removed.

This patch fixes the issue by checking if an existing object already has a valid handle key associated with it, in `sethndl`. If so, simply updates its handle instead of creating a new one.