### PR TITLE
[COREVM-210] Add support for comparison operators in Python

### DIFF
--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -224,6 +224,8 @@ class CodeTransformer(ast.NodeVisitor):
 
         if any(
             (
+                isinstance(op, ast.Eq),
+                isinstance(op, ast.NotEq),
                 isinstance(op, ast.Lt),
                 isinstance(op, ast.LtE),
                 isinstance(op, ast.Gt),
@@ -327,6 +329,12 @@ class CodeTransformer(ast.NodeVisitor):
 
     def visit_Is(self, node):
         return 'is'
+
+    def visit_Eq(self, node):
+        return '__eq__'
+
+    def visit_NotEq(self, node):
+        return '__neq__'
 
     def visit_Lt(self, node):
         return '__lt__'

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -222,6 +222,8 @@ class CodeTransformer(ast.NodeVisitor):
         # Note: Only supports one comparison now.
         op = node.ops[0]
 
+        # TODO: special support for `is` and `is not` can be removed once
+        # dynamic dispatching is supported.
         if any(
             (
                 isinstance(op, ast.Eq),
@@ -328,7 +330,14 @@ class CodeTransformer(ast.NodeVisitor):
     """ ----------------------------- cmpop -------------------------------- """
 
     def visit_Is(self, node):
+        # TODO: special support for `is` and `is not` can be removed once
+        # dynamic dispatching is supported.
         return 'is'
+
+    def visit_IsNot(self, node):
+        # TODO: special support for `is` and `is not` can be removed once
+        # dynamic dispatching is supported.
+        print 'is not'
 
     def visit_Eq(self, node):
         return '__eq__'

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -173,7 +173,7 @@ class CodeTransformer(ast.NodeVisitor):
     def visit_If(self, node):
         base_str = '{indentation}if {expr}:\n'.format(
             indentation=self.__indentation(),
-            expr=node.test
+            expr=self.visit(node.test)
         )
 
         self.__indent()
@@ -220,12 +220,29 @@ class CodeTransformer(ast.NodeVisitor):
 
     def visit_Compare(self, node):
         # Note: Only supports one comparison now.
-        base_str = '{indentation}{left} {op} {comparator}'.format(
-          indentation=self.__indentation(),
-          left=self.visit(node.left),
-          op=self.visit(node.ops[0]),
-          comparator=self.visit(node.comparators[0])
-        )
+        op = node.ops[0]
+
+        if any(
+            (
+                isinstance(op, ast.Lt),
+                isinstance(op, ast.LtE),
+                isinstance(op, ast.Gt),
+                isinstance(op, ast.GtE),
+            )
+        ):
+            base_str='{indentation}__call({left}.{op_func}, {right})'.format(
+                indentation=self.__indentation(),
+                left=self.visit(node.left),
+                op_func=self.visit(op),
+                right=self.visit(node.comparators[0])
+            )
+        else:
+            base_str = '{indentation}{left} {op} {comparator}'.format(
+              indentation=self.__indentation(),
+              left=self.visit(node.left),
+              op=self.visit(op),
+              comparator=self.visit(node.comparators[0])
+            )
 
         return base_str
 
@@ -310,6 +327,18 @@ class CodeTransformer(ast.NodeVisitor):
 
     def visit_Is(self, node):
         return 'is'
+
+    def visit_Lt(self, node):
+        return '__lt__'
+
+    def visit_LtE(self, node):
+        return '__lte__'
+
+    def visit_Gt(self, node):
+        return '__gt__'
+
+    def visit_GtE(self, node):
+        return '__gte__'
 
     """ ------------------------- comprehension ---------------------------- """
 

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -222,8 +222,6 @@ class CodeTransformer(ast.NodeVisitor):
         # Note: Only supports one comparison now.
         op = node.ops[0]
 
-        # TODO: special support for `is` and `is not` can be removed once
-        # dynamic dispatching is supported.
         if any(
             (
                 isinstance(op, ast.Eq),
@@ -241,6 +239,8 @@ class CodeTransformer(ast.NodeVisitor):
                 right=self.visit(node.comparators[0])
             )
         else:
+            # TODO: special support for `is` and `is not` can be removed once
+            # dynamic dispatching is supported.
             base_str = '{indentation}{left} {op} {comparator}'.format(
               indentation=self.__indentation(),
               left=self.visit(node.left),

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -659,12 +659,10 @@ class BytecodeGenerator(ast.NodeVisitor):
     """ ----------------------------- cmpop -------------------------------- """
 
     def visit_Eq(self, node):
-        self.__add_instr('eq', 0, 0, loc=Loc.from_node(node))
-        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
+        pass
 
     def visit_NotEq(self, node):
-        self.__add_instr('neq', 0, 0)
-        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
+        pass
 
     def visit_Lt(self, node):
         pass

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -667,20 +667,16 @@ class BytecodeGenerator(ast.NodeVisitor):
         self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_Lt(self, node):
-        self.__add_instr('lt', 0, 0)
-        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
+        pass
 
     def visit_LtE(self, node):
-        self.__add_instr('lte', 0, 0)
-        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
+        pass
 
     def visit_Gt(self, node):
-        self.__add_instr('gt', 0, 0)
-        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
+        pass
 
     def visit_GtE(self, node):
-        self.__add_instr('gte', 0, 0)
-        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
+        pass
 
     def visit_Is(self, node):
         self.__add_instr('objeq', 0, 0)

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -677,10 +677,14 @@ class BytecodeGenerator(ast.NodeVisitor):
         pass
 
     def visit_Is(self, node):
+        # TODO: logic can be placed under `object.__eq__` once
+        # dynamic dispatching is supported.
         self.__add_instr('objeq', 0, 0)
         self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_IsNot(self, node):
+        # TODO: logic can be placed under `object.__eq__` once
+        # dynamic dispatching is supported.
         self.__add_instr('objneq', 0, 0)
         self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 

--- a/python/src/bool.py
+++ b/python/src/bool.py
@@ -103,6 +103,8 @@ class bool(object):
         """
         return __call(bool, res_)
 
+    # TODO: Equality methods can be placed under `object` once
+    # dynamic dispatching is supported.
     def __eq__(self, other):
         """
         ### BEGIN VECTOR ###

--- a/python/src/bool.py
+++ b/python/src/bool.py
@@ -18,7 +18,6 @@ class bool(object):
         else:
             return __call(str, 'False')
 
-
     def __add__(self, value):
         """
         ### BEGIN VECTOR ###
@@ -97,6 +96,74 @@ class bool(object):
         [gethndl, 0, 0]
         [pop, 0, 0]
         [mod, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __lt__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [lt, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __lte__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [lte, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __gt__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [gt, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __gte__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [gte, 0, 0]
         [new, 0, 0]
         [sethndl, 0, 0]
         [stobj, res_, 0]

--- a/python/src/bool.py
+++ b/python/src/bool.py
@@ -103,6 +103,40 @@ class bool(object):
         """
         return __call(bool, res_)
 
+    def __eq__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [eq, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __neq__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [neq, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
     def __lt__(self, other):
         """
         ### BEGIN VECTOR ###

--- a/python/src/float.py
+++ b/python/src/float.py
@@ -111,6 +111,40 @@ class float(object):
         """
         return __call(float, res_)
 
+    def __eq__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [eq, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __neq__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [neq, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
     def __lt__(self, other):
         """
         ### BEGIN VECTOR ###

--- a/python/src/float.py
+++ b/python/src/float.py
@@ -111,6 +111,8 @@ class float(object):
         """
         return __call(float, res_)
 
+    # TODO: Equality methods can be placed under `object` once
+    # dynamic dispatching is supported.
     def __eq__(self, other):
         """
         ### BEGIN VECTOR ###

--- a/python/src/float.py
+++ b/python/src/float.py
@@ -110,3 +110,71 @@ class float(object):
         ### END VECTOR ###
         """
         return __call(float, res_)
+
+    def __lt__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [lt, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __lte__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [lte, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __gt__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [gt, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __gte__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [gte, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)

--- a/python/src/int.py
+++ b/python/src/int.py
@@ -112,6 +112,40 @@ class int(object):
         """
         return __call(int, res_)
 
+    def __eq__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [eq, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __neq__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [neq, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
     def __lt__(self, other):
         """
         ### BEGIN VECTOR ###

--- a/python/src/int.py
+++ b/python/src/int.py
@@ -112,6 +112,8 @@ class int(object):
         """
         return __call(int, res_)
 
+    # TODO: Equality methods can be placed under `object` once
+    # dynamic dispatching is supported.
     def __eq__(self, other):
         """
         ### BEGIN VECTOR ###

--- a/python/src/int.py
+++ b/python/src/int.py
@@ -111,3 +111,71 @@ class int(object):
         ### END VECTOR ###
         """
         return __call(int, res_)
+
+    def __lt__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [lt, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __lte__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [lte, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __gt__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [gt, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __gte__(self, other):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, other, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [gte, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -14,6 +14,12 @@ True is False
 # print False / True
 # print False % True
 
+if True == bool(1):
+    print 'Integrity of truth is rock solid'
+
+if False != True:
+    print 'Opposite polarity do not match'
+
 if False < True:
     print 'The truth always triumphs'
 

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -13,3 +13,15 @@ True is False
 # print True * False
 # print False / True
 # print False % True
+
+if False < True:
+    print 'The truth always triumphs'
+
+if bool(0) <= bool(1):
+    print 'The truth still triumphs'
+
+if True > False:
+    print 'The truth remains triumphant'
+
+if bool(100) >= bool(0):
+    print 'The truth remains triumphant eternally'

--- a/python/tests/float.py
+++ b/python/tests/float.py
@@ -4,5 +4,18 @@ print 1.329431 + 5.953167
 print 99.838301 - 99.000123
 print 123.456 * 987.654
 print 999.666333 / 3.00
+
 # TODO: [COREVM-196] Modulus operator for float type inaccurate
 #print 100.000001 % 33.000000
+
+if 1.0 < 1.1:
+    print 'Precision is key'
+
+if 1.123456789 <= 1.123456789:
+    print 'Relentless pursuit of high-precision engineering'
+
+if float(1.0) > float(0.99):
+    print 'My statement still holds true'
+
+if float(0.992) >= float(0.991):
+    print 'You know the story'

--- a/python/tests/float.py
+++ b/python/tests/float.py
@@ -8,6 +8,12 @@ print 999.666333 / 3.00
 # TODO: [COREVM-196] Modulus operator for float type inaccurate
 #print 100.000001 % 33.000000
 
+if 1.01 == 1.01:
+    print 'A fact is a fact.'
+
+if 1.01 != 1.02:
+    print 'Zero tolerance on imprecision here'
+
 if 1.0 < 1.1:
     print 'Precision is key'
 

--- a/python/tests/int.py
+++ b/python/tests/int.py
@@ -6,6 +6,13 @@ print 567 * 654
 print 101 / 11
 print 110 % 33
 
+
+if 1 == 1:
+    print 'You cannot argue with that'
+
+if 1 != 2:
+    print 'Affirmative'
+
 if 1 < 2:
     print '1 < 2 is correct'
 

--- a/python/tests/int.py
+++ b/python/tests/int.py
@@ -5,3 +5,15 @@ print 987654321 - 123456789
 print 567 * 654
 print 101 / 11
 print 110 % 33
+
+if 1 < 2:
+    print '1 < 2 is correct'
+
+if 1 + 1 >= 2:
+    print '1 + 1 >= 2 is also true'
+
+if 100 / 10 <= 100 / 9:
+    print 'We can do division :-)'
+
+if 123 * 321 >= 321 * 123:
+    print 'Multiplication is commutative'


### PR DESCRIPTION
This patch adds support for the following comparison operators in Python, for the basic types `int`, `bool`, and `float`:

* `__eq__`
* `__neq__`
* `__lt__`
* `__lte__`
* `__gt__`
* `__gte__`