### PR TITLE
[COREVM-211] Add support for logical operators in Python

### DIFF
--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -206,6 +206,10 @@ class CodeTransformer(ast.NodeVisitor):
 
     """ ----------------------------- expr --------------------------------- """
 
+    def visit_BoolOp(self, node):
+        return (' %s ' % self.visit(node.op)).join(
+            [self.visit(value) for value in node.values])
+
     def visit_BinOp(self, node):
         base_str = '__call({lhs}.{func}, {rhs})'
 
@@ -304,6 +308,14 @@ class CodeTransformer(ast.NodeVisitor):
 
     def visit_Str(self, node):
         return '__call(str, \"%s\")' % str(node.s)
+
+    """ ---------------------------- boolop -------------------------------- """
+
+    def visit_And(self, node):
+        return 'and'
+
+    def visit_Or(self, node):
+        return 'or'
 
     """ --------------------------- operator ------------------------------- """
 

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -467,12 +467,13 @@ class BytecodeGenerator(ast.NodeVisitor):
         self.visit(node.test)
         self.__add_instr('gethndl', 0, 0, loc=Loc.from_node(node))
         self.__add_instr('truthy', 0, 0, loc=Loc.from_node(node))
+        self.__add_instr('lnot', 0, 0, loc=Loc.from_node(node))
 
         # Add `jmpif` here.
         self.__add_instr('jmpif', 0, 0, loc=Loc.from_node(node))
         vector_length1 = len(self.__current_vector())
 
-        for stmt in node.orelse:
+        for stmt in node.body:
             self.visit(stmt)
 
         # Add `jmpif` here.
@@ -481,7 +482,7 @@ class BytecodeGenerator(ast.NodeVisitor):
         self.__current_vector()[vector_length1 - 1] = Instr(
             self.instr_str_to_code_map['jmpif'], length_diff, 0)
 
-        for stmt in node.body:
+        for stmt in node.orelse:
             self.visit(stmt)
 
     def visit_Expr(self, node):
@@ -491,6 +492,57 @@ class BytecodeGenerator(ast.NodeVisitor):
         pass
 
     """ ----------------------------- expr --------------------------------- """
+
+    def visit_BoolOp(self, node):
+        assert len(node.values) >= 2
+
+        left_name = self.__get_random_name()
+        right_name = self.__get_random_name()
+
+        assert left_name != right_name
+
+        left_name_id = self.__get_encoding_id(left_name)
+        right_name_id = self.__get_encoding_id(right_name)
+
+        assert isinstance(node.op, ast.And) or isinstance(node.op, ast.Or)
+
+        op_instr = 'land' if isinstance(node.op, ast.And) else 'lor'
+
+        jmp_lengths = []
+
+        self.visit(node.values[0])
+        self.__add_instr('stobj2', left_name_id, 0)
+
+        self.visit(node.values[1])
+        self.__add_instr('stobj2', right_name_id, 0)
+
+        self.__add_instr('ldobj2', left_name_id, 0)
+        self.__add_instr('gethndl', 0, 0)
+        self.__add_instr('ldobj2', right_name_id, 0)
+        self.__add_instr('gethndl', 0, 0)
+        self.__add_instr(op_instr, 0, 0)
+        self.__add_instr('jmpif', 0, 0)
+
+        jmp_lengths.append(len(self.__current_vector()))
+
+        for i in xrange(2, len(node.values)):
+            self.visit(node.values[i])
+
+            self.__add_instr('gethndl', 0, 0)
+            self.__add_instr('bool', 0, 0)
+            self.__add_instr(op_instr, 0, 0)
+            self.__add_instr('jmpif', 0, 0)
+
+            jmp_lengths.append(len(self.__current_vector()))
+
+        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
+        current_length = len(self.__current_vector())
+
+        for jmp_length in jmp_lengths:
+            length_diff = current_length - jmp_length
+
+            self.__current_vector()[jmp_length - 1] = Instr(
+                self.instr_str_to_code_map['jmpif'], length_diff, 0)
 
     def visit_BinOp(self, node):
         self.visit(node.right)
@@ -596,6 +648,14 @@ class BytecodeGenerator(ast.NodeVisitor):
         # Note: ignoring ctx here
         self.visit(node.value)
         self.__add_instr('getattr', self.__get_encoding_id(node.attr), 0, loc=Loc.from_node(node))
+
+    """ ---------------------------- boolop -------------------------------- """
+
+    def visit_And(self, node):
+        pass
+
+    def visit_Or(self, node):
+        pass
 
     """ --------------------------- operator ------------------------------- """
 

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -535,7 +535,8 @@ class BytecodeGenerator(ast.NodeVisitor):
                 jmp_lengths.append(len(self.__current_vector()))
 
             current_length = len(self.__current_vector())
-            self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
+            self.__add_instr('cldobj',
+                self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
             for jmp_length in jmp_lengths:
                 length_diff = current_length - jmp_length
@@ -566,7 +567,8 @@ class BytecodeGenerator(ast.NodeVisitor):
 
             self.__add_instr('ldobj2', right_name_id, 0)
             self.__add_instr('gethndl', 0, 0)
-            self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
+            self.__add_instr('cldobj',
+                self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_BinOp(self, node):
         self.visit(node.right)
@@ -764,13 +766,15 @@ class BytecodeGenerator(ast.NodeVisitor):
         # TODO: logic can be placed under `object.__eq__` once
         # dynamic dispatching is supported.
         self.__add_instr('objeq', 0, 0)
-        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
+        self.__add_instr('cldobj',
+            self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_IsNot(self, node):
         # TODO: logic can be placed under `object.__eq__` once
         # dynamic dispatching is supported.
         self.__add_instr('objneq', 0, 0)
-        self.__add_instr('cldobj', self.__get_encoding_id('True'), self.__get_encoding_id('False'))
+        self.__add_instr('cldobj',
+            self.__get_encoding_id('True'), self.__get_encoding_id('False'))
 
     def visit_In(self, node):
         pass

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -506,8 +506,6 @@ class BytecodeGenerator(ast.NodeVisitor):
 
         assert isinstance(node.op, ast.And) or isinstance(node.op, ast.Or)
 
-        op_instr = 'land' if isinstance(node.op, ast.And) else 'lor'
-
         if isinstance(node.op, ast.Or):
             jmp_lengths = []
 

--- a/python/tests/boolop.py
+++ b/python/tests/boolop.py
@@ -1,0 +1,28 @@
+if 1 or 0:
+    print '1 or 0 == True'
+
+if 0 or 0:
+    print 'This cannot be said'
+
+if 1 and 0:
+    print 'This is a secret'
+
+if 0 and 0:
+    print 'This cannot be said too'
+
+if 1 and 2 and 3 or 4:
+    print 'Hello'
+
+if 1 and 2 and 0:
+    print 'Be quite!!!'
+
+if (1 and 2) or (3 and 0):
+    print 'This is now public'
+
+if (0 and 1) and (3 and 4):
+    print 'Skip this round'
+
+if 0 or 0.0 or False:
+    print 'Too much negativity is bad'
+elif 0 or 0.0 or False or True:
+    print 'Gotta have something positive'

--- a/python/tests/int.py
+++ b/python/tests/int.py
@@ -24,3 +24,18 @@ if 100 / 10 <= 100 / 9:
 
 if 123 * 321 >= 321 * 123:
     print 'Multiplication is commutative'
+
+if 1 or 0:
+    print '1 or 0 == True'
+
+if 0 or 0:
+    print 'This cannot be said'
+
+if 1 and 0:
+    print 'This is a secret'
+
+if 0 and 0:
+    print 'This cannot be said too'
+
+if 1 and 2 and 3 or 4:
+    print 'Hello'

--- a/python/tests/int.py
+++ b/python/tests/int.py
@@ -24,18 +24,3 @@ if 100 / 10 <= 100 / 9:
 
 if 123 * 321 >= 321 * 123:
     print 'Multiplication is commutative'
-
-if 1 or 0:
-    print '1 or 0 == True'
-
-if 0 or 0:
-    print 'This cannot be said'
-
-if 1 and 0:
-    print 'This is a secret'
-
-if 0 and 0:
-    print 'This cannot be said too'
-
-if 1 and 2 and 3 or 4:
-    print 'Hello'

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -1143,7 +1143,7 @@ corevm::runtime::instr_handler_jmpif::execute(
     THROW(corevm::runtime::invalid_instr_addr_error());
   }
 
-  corevm::types::native_type_handle hndl = frame.pop_eval_stack();
+  corevm::types::native_type_handle hndl = frame.top_eval_stack();
   corevm::types::native_type_handle hndl2;
 
   corevm::types::interface_to_bool(hndl, hndl2);


### PR DESCRIPTION
Add support for logical operators in Python, specifically, the `and` and `or` keywords.