### PR TITLE
[COREVM-215] Add support for unary operators in Python

### DIFF
--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -218,6 +218,11 @@ class CodeTransformer(ast.NodeVisitor):
             rhs=self.visit(node.right)
         )
 
+    def visit_UnaryOp(self, node):
+        return '__call({operand}.{op_func})'.format(
+            operand=self.visit(node.operand),
+            op_func=self.visit(node.op))
+
     def visit_Lambda(self, node):
         return 'lambda {args}: {body}'.format(
             args=self.visit(node.args),
@@ -344,8 +349,17 @@ class CodeTransformer(ast.NodeVisitor):
 
     """ ---------------------------- unaryop ------------------------------- """
 
+    def visit_Invert(self, node):
+        return '__invert__'
+
     def visit_Not(self, node):
-        return 'not'
+        return '__not__'
+
+    def visit_UAdd(self, node):
+        return '__pos__'
+
+    def visit_USub(self, node):
+        return '__neg__'
 
     """ ----------------------------- cmpop -------------------------------- """
 

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -784,16 +784,16 @@ class BytecodeGenerator(ast.NodeVisitor):
     """ ---------------------------- unaryop ------------------------------- """
 
     def visit_Invert(self, node):
-        self.__add_instr('bnot', 0, 0)
+        pass
 
     def visit_Not(self, node):
-        self.__add_instr('lnot', 0, 0)
+        pass
 
     def visit_UAdd(self, node):
-        self.__add_instr('pos', 0, 0)
+        pass
 
     def visit_USub(self, node):
-        self.__add_instr('neg', 0, 0)
+        pass
 
     """ ----------------------------- cmpop -------------------------------- """
 

--- a/python/src/bool.py
+++ b/python/src/bool.py
@@ -103,6 +103,61 @@ class bool(object):
         """
         return __call(bool, res_)
 
+    def __invert__(self):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [2int8, 0, 0]
+        [bnot, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __not__(self):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [lnot, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __pos__(self):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [2int8, 0, 0]
+        [pos, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __neg__(self):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [2int8, 0, 0]
+        [neg, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
     # TODO: Equality methods can be placed under `object` once
     # dynamic dispatching is supported.
     def __eq__(self, other):

--- a/python/src/float.py
+++ b/python/src/float.py
@@ -111,6 +111,34 @@ class float(object):
         """
         return __call(float, res_)
 
+    # NOTE: `float` type does not support `__invert__` and `__not__`.
+
+    def __pos__(self):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pos, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(float, res_)
+
+    def __neg__(self):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [neg, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(float, res_)
+
     # TODO: Equality methods can be placed under `object` once
     # dynamic dispatching is supported.
     def __eq__(self, other):

--- a/python/src/int.py
+++ b/python/src/int.py
@@ -112,6 +112,58 @@ class int(object):
         """
         return __call(int, res_)
 
+    def __invert__(self):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [bnot, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __not__(self):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [lnot, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(bool, res_)
+
+    def __pos__(self):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pos, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __neg__(self):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [neg, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
     # TODO: Equality methods can be placed under `object` once
     # dynamic dispatching is supported.
     def __eq__(self, other):

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -4,6 +4,18 @@ print bool(1)
 print bool(0)
 True is False
 
+# Python returns int type.
+print ~True
+print ~bool(0)
+
+print not True
+print not bool(0)
+
+print -True
+print +False
+print -(+True)
+print +(-(+bool(0)))
+
 # NOTE: Python prints arithmetic operations on bools as `1`s and `0`s, but we
 # actually print them as `True` and `False`, so can't do stdout comparision.
 # ( Kinda sad :'( )

--- a/python/tests/float.py
+++ b/python/tests/float.py
@@ -5,6 +5,12 @@ print 99.838301 - 99.000123
 print 123.456 * 987.654
 print 999.666333 / 3.00
 
+# NOTE: We cannot simply do `-9.999999` here because the Python ast module
+# treats that as a unary negation operator applied on a floating number.
+print -(9.999999)
+print +10.123456
+print +(-(-(123.725197)))
+
 # TODO: [COREVM-196] Modulus operator for float type inaccurate
 #print 100.000001 % 33.000000
 

--- a/python/tests/float.py
+++ b/python/tests/float.py
@@ -5,8 +5,10 @@ print 99.838301 - 99.000123
 print 123.456 * 987.654
 print 999.666333 / 3.00
 
-# NOTE: We cannot simply do `-9.999999` here because the Python ast module
-# treats that as a unary negation operator applied on a floating number.
+# NOTE: We cannot simply do `-9.999999` here because the Python `ast` module
+# treats that as a single number instead of a unary negation operator applied
+# on a floating number.
+# (Python 2.7.6 on Ubuntu 14.04).
 print -(9.999999)
 print +10.123456
 print +(-(-(123.725197)))

--- a/python/tests/int.py
+++ b/python/tests/int.py
@@ -6,6 +6,16 @@ print 567 * 654
 print 101 / 11
 print 110 % 33
 
+print ~1
+print ~0
+
+print not 1
+print not 0
+
+print -1
+print +0
+print -(+123)
+print +(-(+321))
 
 if 1 == 1:
     print 'You cannot argue with that'


### PR DESCRIPTION
Add support for unary operates in Python. Specifically, this encompasses the following operators:

* Invert operator (bitwise not).
* Not operator (logical not).
* Unary addition.
* Unary subtraction.