### PR TITLE
[COREVM-216] Add support for binary operators in Python

### DIFF
--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -365,6 +365,9 @@ class CodeTransformer(ast.NodeVisitor):
     def visit_BitAnd(self, node):
         return '__and__'
 
+    def visit_FloorDiv(self, node):
+        return '__floordiv__'
+
     """ ---------------------------- unaryop ------------------------------- """
 
     def visit_Invert(self, node):

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -347,6 +347,24 @@ class CodeTransformer(ast.NodeVisitor):
     def visit_Mod(self, node):
         return '__mod__'
 
+    def visit_Pow(self, node):
+        return '__pow__'
+
+    def visit_LShift(self, node):
+        return '__lshift__'
+
+    def visit_RShift(self, node):
+        return '__rshift__'
+
+    def visit_BitOr(self, node):
+        return '__or__'
+
+    def visit_BitXor(self, node):
+        return '__xor__'
+
+    def visit_BitAnd(self, node):
+        return '__and__'
+
     """ ---------------------------- unaryop ------------------------------- """
 
     def visit_Invert(self, node):

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -781,6 +781,9 @@ class BytecodeGenerator(ast.NodeVisitor):
     def visit_BitAnd(self, node):
         pass
 
+    def visit_FloorDiv(self, node):
+        pass
+
     """ ---------------------------- unaryop ------------------------------- """
 
     def visit_Invert(self, node):

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -764,22 +764,22 @@ class BytecodeGenerator(ast.NodeVisitor):
         pass
 
     def visit_Pow(self, node):
-        self.__add_binary_operator_instr('pow')
+        pass
 
     def visit_LShift(self, node):
-        self.__add_binary_operator_instr('bls')
+        pass
 
     def visit_RShift(self, node):
-        self.__add_binary_operator_instr('rls')
+        pass
 
     def visit_BitOr(self, node):
-        self.__add_binary_operator_instr('bor')
+        pass
 
     def visit_BitXor(self, node):
-        self.__add_binary_operator_instr('bxor')
+        pass
 
     def visit_BitAnd(self, node):
-        self.__add_binary_operator_instr('band')
+        pass
 
     """ ---------------------------- unaryop ------------------------------- """
 

--- a/python/src/bool.py
+++ b/python/src/bool.py
@@ -103,6 +103,109 @@ class bool(object):
         """
         return __call(bool, res_)
 
+    def __pow__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [pow, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __lshift__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [bls, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __rshift__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [brs, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __or__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [bor, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __xor__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [bxor, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __and__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [band, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+
     def __invert__(self):
         """
         ### BEGIN VECTOR ###

--- a/python/src/bool.py
+++ b/python/src/bool.py
@@ -205,6 +205,22 @@ class bool(object):
         """
         return __call(int, res_)
 
+    def __floordiv__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [div, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
 
     def __invert__(self):
         """

--- a/python/src/float.py
+++ b/python/src/float.py
@@ -111,6 +111,23 @@ class float(object):
         """
         return __call(float, res_)
 
+    def __pow__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [pow, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(float, res_)
+
     # NOTE: `float` type does not support `__invert__` and `__not__`.
 
     def __pos__(self):

--- a/python/src/float.py
+++ b/python/src/float.py
@@ -128,6 +128,23 @@ class float(object):
         """
         return __call(float, res_)
 
+    def __floordiv__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [div, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
     # NOTE: `float` type does not support `__invert__` and `__not__`.
 
     def __pos__(self):

--- a/python/src/int.py
+++ b/python/src/int.py
@@ -112,6 +112,108 @@ class int(object):
         """
         return __call(int, res_)
 
+    def __pow__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [pow, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __lshift__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [bls, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __rshift__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [brs, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __or__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [bor, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __xor__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [bxor, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
+    def __and__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [band, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
     def __invert__(self):
         """
         ### BEGIN VECTOR ###

--- a/python/src/int.py
+++ b/python/src/int.py
@@ -214,6 +214,23 @@ class int(object):
         """
         return __call(int, res_)
 
+    def __floordiv__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [div, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
     def __invert__(self):
         """
         ### BEGIN VECTOR ###

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -12,6 +12,7 @@ False & True
 True & bool(1)
 True ^ bool(0)
 bool(0) ^ bool(1)
+bool(1) // bool(1)
 
 # Python returns int type.
 print ~True

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -3,6 +3,15 @@ print False
 print bool(1)
 print bool(0)
 True is False
+True ** False
+False << True
+True >> False
+True | False
+bool(0) | False
+False & True
+True & bool(1)
+True ^ bool(0)
+bool(0) ^ bool(1)
 
 # Python returns int type.
 print ~True

--- a/python/tests/float.py
+++ b/python/tests/float.py
@@ -5,6 +5,7 @@ print 99.838301 - 99.000123
 print 123.456 * 987.654
 print 999.666333 / 3.00
 print 9.234 ** 4.76
+print int(9.99 // 3.31) # precision issue
 
 # NOTE: We cannot simply do `-9.999999` here because the Python `ast` module
 # treats that as a single number instead of a unary negation operator applied

--- a/python/tests/float.py
+++ b/python/tests/float.py
@@ -5,7 +5,7 @@ print 99.838301 - 99.000123
 print 123.456 * 987.654
 print 999.666333 / 3.00
 print 9.234 ** 4.76
-print int(9.99 // 3.31) # precision issue
+print int(9.99 // 3.31) # printing precision issue
 
 # NOTE: We cannot simply do `-9.999999` here because the Python `ast` module
 # treats that as a single number instead of a unary negation operator applied

--- a/python/tests/float.py
+++ b/python/tests/float.py
@@ -4,6 +4,7 @@ print 1.329431 + 5.953167
 print 99.838301 - 99.000123
 print 123.456 * 987.654
 print 999.666333 / 3.00
+print 9.234 ** 4.76
 
 # NOTE: We cannot simply do `-9.999999` here because the Python `ast` module
 # treats that as a single number instead of a unary negation operator applied

--- a/python/tests/int.py
+++ b/python/tests/int.py
@@ -11,6 +11,7 @@ print 99 >> 2
 print 123 | 321
 print 12345 ^ 67890
 print 10101 & 8563732
+print 5 // 2
 
 print ~1
 print ~0

--- a/python/tests/int.py
+++ b/python/tests/int.py
@@ -5,6 +5,12 @@ print 987654321 - 123456789
 print 567 * 654
 print 101 / 11
 print 110 % 33
+print 2**3
+print 1 << 3
+print 99 >> 2
+print 123 | 321
+print 12345 ^ 67890
+print 10101 & 8563732
 
 print ~1
 print ~0


### PR DESCRIPTION
Add support for the following binary operators in Python:

* Power operator.
* Bitwise OR.
* Bitwise AND.
* Bitwise XOR.
* Bitwise left shift.
* Bitwise right shift.
* Floor division.