### PR TITLE
[COREVM-217] Add support for aug-assignment operations in Python

### DIFF
--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -119,14 +119,28 @@ class CodeTransformer(ast.NodeVisitor):
         return base_str
 
     def visit_AugAssign(self, node):
-        base_str = '{indentation}{target} = __call({target}.{func}, {value})\n'.format(
+        # The `ast` module does not have node types for aug-assignment operators.
+        # So we have to map them to their corresponding methods.
+        OP_AST_TYPE_TO_METHOD_MAP = {
+            ast.Add: '__iadd__',
+            ast.Sub: '__isub__',
+            ast.Mult: '__imul__',
+            ast.Div: '__idiv__',
+            ast.Mod: '__imod__',
+            ast.Pow: '__ipow__',
+            ast.LShift: '__ilshift__',
+            ast.RShift: '__irshift__',
+            ast.BitOr: '__ior__',
+            ast.BitXor: '__ixor__',
+            ast.BitAnd: '__iand__',
+            ast.FloorDiv: '__ifloordiv__',
+        }
+
+        return '{indentation}__call({target}.{func}, {value})\n'.format(
             indentation=self.__indentation(),
             target=self.visit(node.target),
-            func=self.visit(node.op),
-            value=self.visit(node.value)
-        )
-
-        return base_str
+            func=OP_AST_TYPE_TO_METHOD_MAP[type(node.op)],
+            value=self.visit(node.value))
 
     def visit_Print(self, node):
         base_str = '{indentation}print'.format(indentation=self.__indentation())

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -275,7 +275,7 @@ class CodeTransformer(ast.NodeVisitor):
         else:
             # TODO: special support for `is` and `is not` can be removed once
             # dynamic dispatching is supported.
-            base_str = '{indentation}{left} {op} {comparator}'.format(
+            base_str = '{indentation}({left} {op} {comparator})'.format(
               indentation=self.__indentation(),
               left=self.visit(node.left),
               op=self.visit(op),
@@ -406,7 +406,7 @@ class CodeTransformer(ast.NodeVisitor):
     def visit_IsNot(self, node):
         # TODO: special support for `is` and `is not` can be removed once
         # dynamic dispatching is supported.
-        print 'is not'
+        return 'is not'
 
     def visit_Eq(self, node):
         return '__eq__'

--- a/python/src/bool.py
+++ b/python/src/bool.py
@@ -222,6 +222,162 @@ class bool(object):
         """
         return __call(int, res_)
 
+    def __iadd__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [add, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __isub__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [sub, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __imul__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [mul, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __idiv__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [div, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __imod__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [mod, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __ipow__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pow, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __ilshift__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [bls, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __irshift__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [brs, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __ior__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [bor, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __ixor__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [bxor, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __iand__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [band, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __ifloordiv__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [div, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
     def __invert__(self):
         """
         ### BEGIN VECTOR ###

--- a/python/src/float.py
+++ b/python/src/float.py
@@ -145,6 +145,98 @@ class float(object):
         """
         return __call(int, res_)
 
+    def __iadd__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [add, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __isub__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [sub, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __imul__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [mul, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __idiv__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [div, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __imod__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [mod, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __ipow__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pow, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __ifloordiv__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [div, 0, 0]
+        [2int64, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
     # NOTE: `float` type does not support `__invert__` and `__not__`.
 
     def __pos__(self):

--- a/python/src/int.py
+++ b/python/src/int.py
@@ -231,6 +231,163 @@ class int(object):
         """
         return __call(int, res_)
 
+    def __iadd__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [add, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __isub__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [sub, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __imul__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [mul, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __idiv__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [div, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __imod__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [mod, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __ipow__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [pow, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __ilshift__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [bls, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __irshift__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [brs, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __ior__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [bor, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __ixor__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [bxor, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __iand__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [band, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
+    def __ifloordiv__(self, value):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, value, 0]
+        [gethndl, 0, 0]
+        [pop, 0, 0]
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [div, 0, 0]
+        [2int64, 0, 0]
+        [sethndl, 0, 0]
+        ### END VECTOR ###
+        """
+
     def __invert__(self):
         """
         ### BEGIN VECTOR ###

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -1,18 +1,11 @@
+## -------------------------- Representation Tests -----------------------------
+
 print True
 print False
 print bool(1)
 print bool(0)
-True is False
-True ** False
-False << True
-True >> False
-True | False
-bool(0) | False
-False & True
-True & bool(1)
-True ^ bool(0)
-bool(0) ^ bool(1)
-bool(1) // bool(1)
+
+## -------------------------- Unary operator Tests -----------------------------
 
 # Python returns int type.
 print ~True
@@ -25,6 +18,31 @@ print -True
 print +False
 print -(+True)
 print +(-(+bool(0)))
+
+## ------------------------- Binary operator Tests -----------------------------
+
+# NOTE: Python prints arithmetic operations on bools as `1`s and `0`s, but we
+# actually print them as `True` and `False`, so can't do stdout comparision.
+# ( Kinda sad :'( )
+# But the results were verified as correct.
+# print True + False
+# print True - False
+# print True * False
+# print False / True
+# print False % True
+True is False
+True ** False
+False << True
+True >> False
+True | False
+bool(0) | False
+False & True
+True & bool(1)
+True ^ bool(0)
+bool(0) ^ bool(1)
+bool(1) // bool(1)
+
+## --------------------------- Aug-assignment Tests ----------------------------
 
 # NOTE: In Python (tested in v2.7.6), aug-assignments on instances of `bool`
 # type makes the instance itself turn into type `int`. This behavior, however,
@@ -77,15 +95,7 @@ fd = True
 fd //= bool(1)
 print fd == (True // bool(1))
 
-# NOTE: Python prints arithmetic operations on bools as `1`s and `0`s, but we
-# actually print them as `True` and `False`, so can't do stdout comparision.
-# ( Kinda sad :'( )
-# But the results were verified as correct.
-# print True + False
-# print True - False
-# print True * False
-# print False / True
-# print False % True
+## ----------------------------- Comparison Tests ------------------------------
 
 if True == bool(1):
     print 'Integrity of truth is rock solid'

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -26,6 +26,57 @@ print +False
 print -(+True)
 print +(-(+bool(0)))
 
+# NOTE: In Python (tested in v2.7.6), aug-assignments on instances of `bool`
+# type makes the instance itself turn into type `int`. This behavior, however,
+# it not currently supported.
+i = True
+i += False
+print i == (True + False)
+
+j = True
+j -= False
+print j == (True - False)
+
+k = False
+k *= bool(1)
+print k == (False * bool(1))
+
+u = bool(1)
+u /= bool(1)
+print u == (bool(1) / bool(1))
+
+v = bool(1)
+v %= True
+print v == (bool(1) % True)
+
+w = bool(1)
+w **= bool(0)
+print w == (bool(1) ** bool(0))
+
+x = True
+x <<= True
+print x == (True << True)
+
+y = False
+y >>= True
+print y == (False >> True)
+
+z = True
+z |= False
+print z == (True | False)
+
+zeta = bool(1)
+zeta ^= bool(0)
+print zeta == (bool(1) ^ bool(0))
+
+zelda = bool(0)
+zelda &= bool(1)
+print zelda == (bool(0) & bool(1))
+
+fd = True
+fd //= bool(1)
+print fd == (True // bool(1))
+
 # NOTE: Python prints arithmetic operations on bools as `1`s and `0`s, but we
 # actually print them as `True` and `False`, so can't do stdout comparision.
 # ( Kinda sad :'( )

--- a/python/tests/bool.py
+++ b/python/tests/bool.py
@@ -21,26 +21,26 @@ print +(-(+bool(0)))
 
 ## ------------------------- Binary operator Tests -----------------------------
 
+print True is False
+print True is not False
+
 # NOTE: Python prints arithmetic operations on bools as `1`s and `0`s, but we
-# actually print them as `True` and `False`, so can't do stdout comparision.
-# ( Kinda sad :'( )
-# But the results were verified as correct.
-# print True + False
-# print True - False
-# print True * False
-# print False / True
-# print False % True
-True is False
-True ** False
-False << True
-True >> False
-True | False
-bool(0) | False
-False & True
-True & bool(1)
-True ^ bool(0)
-bool(0) ^ bool(1)
-bool(1) // bool(1)
+# actually print them as `True` and `False`.
+print (True + False) == 1
+print (True - False) == 1
+print (True * False) == 0
+print (False / True) == 0
+print (False % True) == 0
+print (True ** False) == 1
+print (False << True) == 1
+print (True >> False) == 1
+print (True | False) == 1
+print (bool(0) | False) == 1
+print (False & True) == 0
+print (True & bool(1)) == 1
+print (True ^ bool(0)) == 1
+print (bool(0) ^ bool(1)) == 1
+print (bool(1) // bool(1)) == 0
 
 ## --------------------------- Aug-assignment Tests ----------------------------
 

--- a/python/tests/float.py
+++ b/python/tests/float.py
@@ -15,6 +15,34 @@ print -(9.999999)
 print +10.123456
 print +(-(-(123.725197)))
 
+i = 1.34
+i += 3.585739
+print i
+
+j = 111.555555
+j -= 110.444444
+print j
+
+k = 123.554
+k *= 321.649
+print k
+
+u = 777.777777
+u /= 7
+print u
+
+v = 639.0
+v %= 5.0
+print v == float(639.0 % 5.0)
+
+w = 23.444
+w **= 3.59
+print w
+
+fd = 368.5
+fd //= 5.0
+print fd == int(368 // 5.0)
+
 # TODO: [COREVM-196] Modulus operator for float type inaccurate
 #print 100.000001 % 33.000000
 

--- a/python/tests/float.py
+++ b/python/tests/float.py
@@ -1,11 +1,9 @@
+## -------------------------- Representation Tests -----------------------------
+
 print 5824.674626
 print float(3.141592)
-print 1.329431 + 5.953167
-print 99.838301 - 99.000123
-print 123.456 * 987.654
-print 999.666333 / 3.00
-print 9.234 ** 4.76
-print int(9.99 // 3.31) # printing precision issue
+
+## -------------------------- Unary operator Tests -----------------------------
 
 # NOTE: We cannot simply do `-9.999999` here because the Python `ast` module
 # treats that as a single number instead of a unary negation operator applied
@@ -14,6 +12,19 @@ print int(9.99 // 3.31) # printing precision issue
 print -(9.999999)
 print +10.123456
 print +(-(-(123.725197)))
+
+## ------------------------- Binary operator Tests -----------------------------
+
+print 1.329431 + 5.953167
+print 99.838301 - 99.000123
+print 123.456 * 987.654
+print 999.666333 / 3.00
+# TODO: [COREVM-196] Modulus operator for float type inaccurate
+#print 100.000001 % 33.000000
+print 9.234 ** 4.76
+print int(9.99 // 3.31) # printing precision issue
+
+## --------------------------- Aug-assignment Tests ----------------------------
 
 i = 1.34
 i += 3.585739
@@ -43,8 +54,8 @@ fd = 368.5
 fd //= 5.0
 print fd == int(368 // 5.0)
 
-# TODO: [COREVM-196] Modulus operator for float type inaccurate
-#print 100.000001 % 33.000000
+
+## ----------------------------- Comparison Tests ------------------------------
 
 if 1.01 == 1.01:
     print 'A fact is a fact.'

--- a/python/tests/int.py
+++ b/python/tests/int.py
@@ -12,7 +12,6 @@ print 123 | 321
 print 12345 ^ 67890
 print 10101 & 8563732
 print 5 // 2
-
 print ~1
 print ~0
 
@@ -23,6 +22,54 @@ print -1
 print +0
 print -(+123)
 print +(-(+321))
+
+i = 1
+i += 3
+print i
+
+j = 111
+j -= 110
+print j
+
+k = 123
+k *= 321
+print k
+
+u = 777
+u /= 7
+print u
+
+v = 639
+v %= 5
+print v
+
+w = 23
+w *= 3
+print w
+
+x = 5000
+x <<= 2
+print x
+
+y = 9999999
+y >>= 3
+print y
+
+z = 12345
+z |= 54321
+print z
+
+zeta = 85638
+zeta ^= 00001
+print zeta
+
+zelda = 55555
+zelda &= 7654321
+print zelda
+
+fd = 368
+fd //= 5
+print fd
 
 if 1 == 1:
     print 'You cannot argue with that'

--- a/python/tests/int.py
+++ b/python/tests/int.py
@@ -44,7 +44,7 @@ v %= 5
 print v
 
 w = 23
-w *= 3
+w **= 3
 print w
 
 x = 5000

--- a/python/tests/int.py
+++ b/python/tests/int.py
@@ -1,5 +1,20 @@
+## -------------------------- Representation Tests -----------------------------
+
 print 1234567890
 print int(987654321)
+
+## -------------------------- Unary operator Tests -----------------------------
+
+print not 1
+print not 0
+
+print -1
+print +0
+print -(+123)
+print +(-(+321))
+
+## ------------------------- Binary operator Tests -----------------------------
+
 print 1 + 2
 print 987654321 - 123456789
 print 567 * 654
@@ -15,13 +30,7 @@ print 5 // 2
 print ~1
 print ~0
 
-print not 1
-print not 0
-
-print -1
-print +0
-print -(+123)
-print +(-(+321))
+## --------------------------- Aug-assignment Tests ----------------------------
 
 i = 1
 i += 3
@@ -70,6 +79,8 @@ print zelda
 fd = 368
 fd //= 5
 print fd
+
+## ----------------------------- Comparison Tests ------------------------------
 
 if 1 == 1:
     print 'You cannot argue with that'


### PR DESCRIPTION
This patch adds support for the aug-assignment operations in Python. Previously, the support was carried out as a two steps operation: 1) Perform the arithmetic/logic/bitwise operation, and 2) perform the assignment. However, aug-assginent operations are actually supported by special methods in Python.