### PR TITLE
[COREVM-219] Implement object flags toggling instruction set

### DIFF
--- a/python/src/bool.py
+++ b/python/src/bool.py
@@ -550,6 +550,15 @@ class bool(object):
 ### END VECTOR ###
 """
 True = __call(bool, 1)
+"""
+### BEGIN VECTOR ###
+[ldobj, True, 0]
+[setflgc, 1, 0]
+[setfldel, 1, 0]
+[setflmute, 1, 0]
+[pop, 0, 0]
+### END VECTOR ###
+"""
 
 
 ### False
@@ -563,5 +572,13 @@ True = __call(bool, 1)
 [stobj, False, 0]
 ### END VECTOR ###
 """
-
 False = __call(bool, 0)
+"""
+### BEGIN VECTOR ###
+[ldobj, False, 0]
+[setflgc, 1, 0]
+[setfldel, 1, 0]
+[setflmute, 1, 0]
+[pop, 0, 0]
+### END VECTOR ###
+"""

--- a/python/src/none.py
+++ b/python/src/none.py
@@ -25,6 +25,9 @@ class NoneType(object):
 __call(NoneType)
 """
 ### BEGIN VECTOR ###
+[setflgc, 1, 0]
+[setfldel, 1, 0]
+[setflmute, 1, 0]
 [stobj, None, 0]
 ### END VECTOR ###
 """

--- a/src/dyobj/flags.h
+++ b/src/dyobj/flags.h
@@ -47,10 +47,6 @@ enum flags : uint32_t
 
   DYOBJ_IS_INDELIBLE,
 
-  /* ------------- Bits that pertain to the scope of objects ---------------- */
-
-  DYOBJ_IS_INVISIBLE_TO_USER,
-
   /* ------- Bits that pertain to the various attributes of objects --------- */
 
   DYOBJ_IS_NON_CALLABLE,
@@ -73,7 +69,6 @@ const std::vector<const char*>
 DYOBJ_FLAG_VALUES_ARRAY {
   "DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE",
   "DYOBJ_IS_INDELIBLE",
-  "DYOBJ_IS_INVISIBLE_TO_USER",
   "DYOBJ_IS_NON_CALLABLE",
   "DYOBJ_IS_IMMUTABLE",
 };

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -103,6 +103,7 @@ corevm::runtime::instr_handler_meta::instr_info_map {
   { corevm::runtime::instr_enum::PUTOBJ,    { .num_oprd=0, .str="putobj",    .handler=std::make_shared<corevm::runtime::instr_handler_putobj>()    } },
   { corevm::runtime::instr_enum::GETOBJ,    { .num_oprd=0, .str="getobj",    .handler=std::make_shared<corevm::runtime::instr_handler_getobj>()    } },
   { corevm::runtime::instr_enum::SETFLGC,   { .num_oprd=1, .str="setflgc",   .handler=std::make_shared<corevm::runtime::instr_handler_setflgc>()   } },
+  { corevm::runtime::instr_enum::SETFLDEL,  { .num_oprd=1, .str="setfldel",  .handler=std::make_shared<corevm::runtime::instr_handler_setfldel>()  } },
   { corevm::runtime::instr_enum::MUTE,      { .num_oprd=1, .str="mute",      .handler=std::make_shared<corevm::runtime::instr_handler_mute>()      } },
   { corevm::runtime::instr_enum::UNMUTE,    { .num_oprd=1, .str="unmute",    .handler=std::make_shared<corevm::runtime::instr_handler_unmute>()    } },
 
@@ -1027,6 +1028,27 @@ corevm::runtime::instr_handler_setflgc::execute(
   else
   {
     obj.clear_flag(corevm::dyobj::flags::DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE);
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::instr_handler_setfldel::execute(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  corevm::dyobj::dyobj_id id = process.top_stack();
+  auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
+
+  bool on_off = static_cast<bool>(instr.oprd1);
+
+  if (on_off)
+  {
+    obj.set_flag(corevm::dyobj::flags::DYOBJ_IS_INDELIBLE);
+  }
+  else
+  {
+    obj.clear_flag(corevm::dyobj::flags::DYOBJ_IS_INDELIBLE);
   }
 }
 

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -104,6 +104,7 @@ corevm::runtime::instr_handler_meta::instr_info_map {
   { corevm::runtime::instr_enum::GETOBJ,    { .num_oprd=0, .str="getobj",    .handler=std::make_shared<corevm::runtime::instr_handler_getobj>()    } },
   { corevm::runtime::instr_enum::SETFLGC,   { .num_oprd=1, .str="setflgc",   .handler=std::make_shared<corevm::runtime::instr_handler_setflgc>()   } },
   { corevm::runtime::instr_enum::SETFLDEL,  { .num_oprd=1, .str="setfldel",  .handler=std::make_shared<corevm::runtime::instr_handler_setfldel>()  } },
+  { corevm::runtime::instr_enum::SETFLCALL, { .num_oprd=1, .str="setflcall", .handler=std::make_shared<corevm::runtime::instr_handler_setflcall>() } },
   { corevm::runtime::instr_enum::MUTE,      { .num_oprd=1, .str="mute",      .handler=std::make_shared<corevm::runtime::instr_handler_mute>()      } },
   { corevm::runtime::instr_enum::UNMUTE,    { .num_oprd=1, .str="unmute",    .handler=std::make_shared<corevm::runtime::instr_handler_unmute>()    } },
 
@@ -1049,6 +1050,27 @@ corevm::runtime::instr_handler_setfldel::execute(
   else
   {
     obj.clear_flag(corevm::dyobj::flags::DYOBJ_IS_INDELIBLE);
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::instr_handler_setflcall::execute(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  corevm::dyobj::dyobj_id id = process.top_stack();
+  auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
+
+  bool on_off = static_cast<bool>(instr.oprd1);
+
+  if (on_off)
+  {
+    obj.set_flag(corevm::dyobj::flags::DYOBJ_IS_NON_CALLABLE);
+  }
+  else
+  {
+    obj.clear_flag(corevm::dyobj::flags::DYOBJ_IS_NON_CALLABLE);
   }
 }
 

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -105,8 +105,7 @@ corevm::runtime::instr_handler_meta::instr_info_map {
   { corevm::runtime::instr_enum::SETFLGC,   { .num_oprd=1, .str="setflgc",   .handler=std::make_shared<corevm::runtime::instr_handler_setflgc>()   } },
   { corevm::runtime::instr_enum::SETFLDEL,  { .num_oprd=1, .str="setfldel",  .handler=std::make_shared<corevm::runtime::instr_handler_setfldel>()  } },
   { corevm::runtime::instr_enum::SETFLCALL, { .num_oprd=1, .str="setflcall", .handler=std::make_shared<corevm::runtime::instr_handler_setflcall>() } },
-  { corevm::runtime::instr_enum::MUTE,      { .num_oprd=1, .str="mute",      .handler=std::make_shared<corevm::runtime::instr_handler_mute>()      } },
-  { corevm::runtime::instr_enum::UNMUTE,    { .num_oprd=1, .str="unmute",    .handler=std::make_shared<corevm::runtime::instr_handler_unmute>()    } },
+  { corevm::runtime::instr_enum::SETFLMUTE, { .num_oprd=1, .str="setflmute", .handler=std::make_shared<corevm::runtime::instr_handler_setflmute>() } },
 
   /* -------------------------- Control instructions ------------------------ */
 
@@ -1077,25 +1076,22 @@ corevm::runtime::instr_handler_setflcall::execute(
 // -----------------------------------------------------------------------------
 
 void
-corevm::runtime::instr_handler_mute::execute(
+corevm::runtime::instr_handler_setflmute::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
   corevm::dyobj::dyobj_id id = process.top_stack();
   auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
 
-  obj.clear_flag(corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE);
-}
+  bool on_off = static_cast<bool>(instr.oprd1);
 
-// -----------------------------------------------------------------------------
-
-void
-corevm::runtime::instr_handler_unmute::execute(
-  const corevm::runtime::instr& instr, corevm::runtime::process& process)
-{
-  corevm::dyobj::dyobj_id id = process.top_stack();
-  auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
-
-  obj.set_flag(corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE);
+  if (on_off)
+  {
+    obj.set_flag(corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE);
+  }
+  else
+  {
+    obj.clear_flag(corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE);
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -86,8 +86,6 @@ corevm::runtime::instr_handler_meta::instr_info_map {
   { corevm::runtime::instr_enum::GETATTR,   { .num_oprd=1, .str="getattr",   .handler=std::make_shared<corevm::runtime::instr_handler_getattr>()   } },
   { corevm::runtime::instr_enum::SETATTR,   { .num_oprd=1, .str="setattr",   .handler=std::make_shared<corevm::runtime::instr_handler_setattr>()   } },
   { corevm::runtime::instr_enum::DELATTR,   { .num_oprd=1, .str="delattr",   .handler=std::make_shared<corevm::runtime::instr_handler_delattr>()   } },
-  { corevm::runtime::instr_enum::MUTE,      { .num_oprd=1, .str="mute",      .handler=std::make_shared<corevm::runtime::instr_handler_mute>()      } },
-  { corevm::runtime::instr_enum::UNMUTE,    { .num_oprd=1, .str="unmute",    .handler=std::make_shared<corevm::runtime::instr_handler_unmute>()    } },
   { corevm::runtime::instr_enum::POP,       { .num_oprd=0, .str="pop",       .handler=std::make_shared<corevm::runtime::instr_handler_pop>()       } },
   { corevm::runtime::instr_enum::LDOBJ2,    { .num_oprd=1, .str="ldobj2",    .handler=std::make_shared<corevm::runtime::instr_handler_ldobj2>()    } },
   { corevm::runtime::instr_enum::STOBJ2,    { .num_oprd=1, .str="stobj2",    .handler=std::make_shared<corevm::runtime::instr_handler_stobj2>()    } },
@@ -104,6 +102,9 @@ corevm::runtime::instr_handler_meta::instr_info_map {
   { corevm::runtime::instr_enum::RSETATTRS, { .num_oprd=1, .str="rsetattrs", .handler=std::make_shared<corevm::runtime::instr_handler_rsetattrs>() } },
   { corevm::runtime::instr_enum::PUTOBJ,    { .num_oprd=0, .str="putobj",    .handler=std::make_shared<corevm::runtime::instr_handler_putobj>()    } },
   { corevm::runtime::instr_enum::GETOBJ,    { .num_oprd=0, .str="getobj",    .handler=std::make_shared<corevm::runtime::instr_handler_getobj>()    } },
+  { corevm::runtime::instr_enum::SETFLGC,   { .num_oprd=1, .str="setflgc",   .handler=std::make_shared<corevm::runtime::instr_handler_setflgc>()   } },
+  { corevm::runtime::instr_enum::MUTE,      { .num_oprd=1, .str="mute",      .handler=std::make_shared<corevm::runtime::instr_handler_mute>()      } },
+  { corevm::runtime::instr_enum::UNMUTE,    { .num_oprd=1, .str="unmute",    .handler=std::make_shared<corevm::runtime::instr_handler_unmute>()    } },
 
   /* -------------------------- Control instructions ------------------------ */
 
@@ -593,30 +594,6 @@ corevm::runtime::instr_handler_delattr::execute(
 // -----------------------------------------------------------------------------
 
 void
-corevm::runtime::instr_handler_mute::execute(
-  const corevm::runtime::instr& instr, corevm::runtime::process& process)
-{
-  corevm::dyobj::dyobj_id id = process.top_stack();
-  auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
-
-  obj.clear_flag(corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE);
-}
-
-// -----------------------------------------------------------------------------
-
-void
-corevm::runtime::instr_handler_unmute::execute(
-  const corevm::runtime::instr& instr, corevm::runtime::process& process)
-{
-  corevm::dyobj::dyobj_id id = process.top_stack();
-  auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
-
-  obj.set_flag(corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE);
-}
-
-// -----------------------------------------------------------------------------
-
-void
 corevm::runtime::instr_handler_pop::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
@@ -1030,6 +1007,51 @@ corevm::runtime::instr_handler_getobj::execute(
     corevm::dyobj::dyobj_id>(hndl);
 
   process.push_stack(id);
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::instr_handler_setflgc::execute(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  corevm::dyobj::dyobj_id id = process.top_stack();
+  auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
+
+  bool on_off = static_cast<bool>(instr.oprd1);
+
+  if (on_off)
+  {
+    obj.set_flag(corevm::dyobj::flags::DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE);
+  }
+  else
+  {
+    obj.clear_flag(corevm::dyobj::flags::DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE);
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::instr_handler_mute::execute(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  corevm::dyobj::dyobj_id id = process.top_stack();
+  auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
+
+  obj.clear_flag(corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE);
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::instr_handler_unmute::execute(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  corevm::dyobj::dyobj_id id = process.top_stack();
+  auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
+
+  obj.set_flag(corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/runtime/instr.h
+++ b/src/runtime/instr.h
@@ -210,6 +210,14 @@ enum instr_enum : uint32_t
   SETFLGC,
 
   /**
+   * <setfldel, #, _>
+   * Sets the `IS_INDELIBLE` flag on the object on top of the stack.
+   * The first operand is a boolean vlaue used to set the value of the flag.
+   * A value of `1` sets the flag, `0` otherwise.
+   */
+  SETFLDEL,
+
+  /**
    * <mute, _, _>
    * Clears the `IS_IMMUTABLE` flag on the object on top of the stack.
    */
@@ -1231,6 +1239,14 @@ public:
 // -----------------------------------------------------------------------------
 
 class instr_handler_setflgc : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_setfldel : public instr_handler
 {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);

--- a/src/runtime/instr.h
+++ b/src/runtime/instr.h
@@ -226,16 +226,12 @@ enum instr_enum : uint32_t
   SETFLCALL,
 
   /**
-   * <mute, _, _>
-   * Clears the `IS_IMMUTABLE` flag on the object on top of the stack.
-   */
-  MUTE,
-
-  /**
-   * <unmute, _, _>
+   * <setflmute, #, _>
    * Sets the `IS_IMMUTABLE` flag on the object on top of the stack.
+   * The first operand is a boolean value used to set the value of the flag.
+   * A value of `1` sets the flag, `0` otherwise.
    */
-  UNMUTE,
+  SETFLMUTE,
 
 
   /* ------------------------ Control instructions -------------------------- */
@@ -1270,15 +1266,7 @@ public:
 
 // -----------------------------------------------------------------------------
 
-class instr_handler_mute : public instr_handler
-{
-public:
-  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
-};
-
-// -----------------------------------------------------------------------------
-
-class instr_handler_unmute : public instr_handler
+class instr_handler_setflmute : public instr_handler
 {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);

--- a/src/runtime/instr.h
+++ b/src/runtime/instr.h
@@ -218,6 +218,14 @@ enum instr_enum : uint32_t
   SETFLDEL,
 
   /**
+   * <setflcall, #, _>
+   * Sets the `IS_NON_CALLABLE` flag on the object on top of the stack.
+   * The first operand is a boolean value used to set the value of the flag.
+   * A value of `1` sets the flag, `0` otherwise.
+   */
+  SETFLCALL,
+
+  /**
    * <mute, _, _>
    * Clears the `IS_IMMUTABLE` flag on the object on top of the stack.
    */
@@ -1247,6 +1255,14 @@ public:
 // -----------------------------------------------------------------------------
 
 class instr_handler_setfldel : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_setflcall : public instr_handler
 {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);

--- a/src/runtime/instr.h
+++ b/src/runtime/instr.h
@@ -88,18 +88,6 @@ enum instr_enum : uint32_t
   DELATTR,
 
   /**
-   * <mute, _, _>
-   * Clears the `IS_IMMUTABLE` flag on the object on top of the stack.
-   */
-  MUTE,
-
-  /**
-   * <unmute, _, _>
-   * Sets the `IS_IMMUTABLE` flag on the object on top of the stack.
-   */
-  UNMUTE,
-
-  /**
    * <pop, _, _>
    * Pops the object on top of the stack.
    */
@@ -211,6 +199,28 @@ enum instr_enum : uint32_t
    * Pops the top of the eval stack, and put its value on the object stack.
    */
   GETOBJ,
+
+  /**
+   * <setflgc, #, _>
+   * Sets the `IS_NOT_GARBAGE_COLLECTIBLE` flag on the object on top of the
+   * stack.
+   * The first operand is a boolean value used to set the value of the flag.
+   * A value of `1` sets the flag, `0` otherwise.
+   */
+  SETFLGC,
+
+  /**
+   * <mute, _, _>
+   * Clears the `IS_IMMUTABLE` flag on the object on top of the stack.
+   */
+  MUTE,
+
+  /**
+   * <unmute, _, _>
+   * Sets the `IS_IMMUTABLE` flag on the object on top of the stack.
+   */
+  UNMUTE,
+
 
   /* ------------------------ Control instructions -------------------------- */
 
@@ -1092,22 +1102,6 @@ public:
 
 // -----------------------------------------------------------------------------
 
-class instr_handler_mute : public instr_handler
-{
-public:
-  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
-};
-
-// -----------------------------------------------------------------------------
-
-class instr_handler_unmute : public instr_handler
-{
-public:
-  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
-};
-
-// -----------------------------------------------------------------------------
-
 class instr_handler_pop : public instr_handler
 {
 public:
@@ -1229,6 +1223,30 @@ public:
 // -----------------------------------------------------------------------------
 
 class instr_handler_getobj : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_setflgc : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_mute : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_unmute : public instr_handler
 {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -259,46 +259,6 @@ TEST_F(instrs_obj_unittest, TestInstrDELATTR)
 
 // -----------------------------------------------------------------------------
 
-TEST_F(instrs_obj_unittest, TestInstrMUTE)
-{
-  corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();
-  m_process.push_stack(id);
-
-  corevm::runtime::instr instr { .code=0, .oprd1=0, .oprd2=0 };
-  execute_instr<corevm::runtime::instr_handler_mute>(instr, 1);
-
-  corevm::dyobj::dyobj_id expected_id = id;
-  corevm::dyobj::dyobj_id actual_id = m_process.top_stack();
-
-  ASSERT_EQ(expected_id, actual_id);
-
-  auto &actual_obj = process::adapter(m_process).help_get_dyobj(actual_id);
-
-  ASSERT_EQ(false, actual_obj.get_flag(corevm::dyobj::DYOBJ_IS_IMMUTABLE));
-}
-
-// -----------------------------------------------------------------------------
-
-TEST_F(instrs_obj_unittest, TestInstrUNMUTE)
-{
-  corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();
-  m_process.push_stack(id);
-
-  corevm::runtime::instr instr { .code=0, .oprd1=0, .oprd2=0 };
-  execute_instr<corevm::runtime::instr_handler_unmute>(instr, 1);
-
-  corevm::dyobj::dyobj_id expected_id = id;
-  corevm::dyobj::dyobj_id actual_id = m_process.top_stack();
-
-  ASSERT_EQ(expected_id, actual_id);
-
-  auto &actual_obj = process::adapter(m_process).help_get_dyobj(actual_id);
-
-  ASSERT_EQ(true, actual_obj.get_flag(corevm::dyobj::DYOBJ_IS_IMMUTABLE));
-}
-
-// -----------------------------------------------------------------------------
-
 TEST_F(instrs_obj_unittest, TestInstrPOP)
 {
   corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();
@@ -839,6 +799,111 @@ TEST_F(instrs_obj_unittest, TestInstrGETOBJ)
   corevm::dyobj::dyobj_id id = m_process.top_stack();
 
   ASSERT_EQ(10, id);
+}
+
+// -----------------------------------------------------------------------------
+
+class instrs_obj_flag_unittest : public instrs_obj_unittest
+{
+protected:
+  void _SetUp()
+  {
+    corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();
+    m_process.push_stack(id);
+  }
+
+  void _TearDown()
+  {
+    m_process.pop_stack();
+  }
+
+  template<class InstrHandlerCls>
+  void execute_instr_and_assert_result(const corevm::dyobj::flags flag)
+  {
+    execute_instr_with_toggle_on<InstrHandlerCls>(flag);
+    execute_instr_with_toggle_off<InstrHandlerCls>(flag);
+  }
+
+private:
+  template<class InstrHandlerCls>
+  void execute_instr_with_toggle_on(const corevm::dyobj::flags flag)
+  {
+    corevm::runtime::instr instr { .code=0, .oprd1=1, .oprd2=0 };
+    _execute_and_assert_result<InstrHandlerCls>(instr, flag);
+  }
+
+  template<class InstrHandlerCls>
+  void execute_instr_with_toggle_off(const corevm::dyobj::flags flag)
+  {
+    corevm::runtime::instr instr { .code=0, .oprd1=0, .oprd2=0 };
+    _execute_and_assert_result<InstrHandlerCls>(instr, flag);
+  }
+
+  template<class InstrHandlerCls>
+  void _execute_and_assert_result(
+    const corevm::runtime::instr& instr, const corevm::dyobj::flags flag)
+  {
+    _SetUp();
+
+    execute_instr<InstrHandlerCls>(instr);
+
+    corevm::dyobj::dyobj_id actual_id = m_process.top_stack();
+    auto &actual_obj = process::adapter(m_process).help_get_dyobj(actual_id);
+
+    bool on_off = static_cast<bool>(instr.oprd1);
+
+    ASSERT_EQ(on_off, actual_obj.get_flag(flag));
+
+    _TearDown();
+  }
+};
+
+// -----------------------------------------------------------------------------
+
+TEST_F(instrs_obj_flag_unittest, TestInstrSETFLGC)
+{
+  execute_instr_and_assert_result<corevm::runtime::instr_handler_setflgc>(
+    corevm::dyobj::flags::DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE);
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(instrs_obj_unittest, TestInstrMUTE)
+{
+  corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();
+  m_process.push_stack(id);
+
+  corevm::runtime::instr instr { .code=0, .oprd1=0, .oprd2=0 };
+  execute_instr<corevm::runtime::instr_handler_mute>(instr, 1);
+
+  corevm::dyobj::dyobj_id expected_id = id;
+  corevm::dyobj::dyobj_id actual_id = m_process.top_stack();
+
+  ASSERT_EQ(expected_id, actual_id);
+
+  auto &actual_obj = process::adapter(m_process).help_get_dyobj(actual_id);
+
+  ASSERT_EQ(false, actual_obj.get_flag(corevm::dyobj::DYOBJ_IS_IMMUTABLE));
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(instrs_obj_unittest, TestInstrUNMUTE)
+{
+  corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();
+  m_process.push_stack(id);
+
+  corevm::runtime::instr instr { .code=0, .oprd1=0, .oprd2=0 };
+  execute_instr<corevm::runtime::instr_handler_unmute>(instr, 1);
+
+  corevm::dyobj::dyobj_id expected_id = id;
+  corevm::dyobj::dyobj_id actual_id = m_process.top_stack();
+
+  ASSERT_EQ(expected_id, actual_id);
+
+  auto &actual_obj = process::adapter(m_process).help_get_dyobj(actual_id);
+
+  ASSERT_EQ(true, actual_obj.get_flag(corevm::dyobj::DYOBJ_IS_IMMUTABLE));
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -876,6 +876,14 @@ TEST_F(instrs_obj_flag_unittest, TestInstrSETFLDEL)
 
 // -----------------------------------------------------------------------------
 
+TEST_F(instrs_obj_flag_unittest, TestInstrSETFLCALL)
+{
+  execute_instr_and_assert_result<corevm::runtime::instr_handler_setflcall>(
+    corevm::dyobj::flags::DYOBJ_IS_NON_CALLABLE);
+}
+
+// -----------------------------------------------------------------------------
+
 TEST_F(instrs_obj_unittest, TestInstrMUTE)
 {
   corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -884,42 +884,10 @@ TEST_F(instrs_obj_flag_unittest, TestInstrSETFLCALL)
 
 // -----------------------------------------------------------------------------
 
-TEST_F(instrs_obj_unittest, TestInstrMUTE)
+TEST_F(instrs_obj_flag_unittest, TestInstrSETFLMUTE)
 {
-  corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();
-  m_process.push_stack(id);
-
-  corevm::runtime::instr instr { .code=0, .oprd1=0, .oprd2=0 };
-  execute_instr<corevm::runtime::instr_handler_mute>(instr, 1);
-
-  corevm::dyobj::dyobj_id expected_id = id;
-  corevm::dyobj::dyobj_id actual_id = m_process.top_stack();
-
-  ASSERT_EQ(expected_id, actual_id);
-
-  auto &actual_obj = process::adapter(m_process).help_get_dyobj(actual_id);
-
-  ASSERT_EQ(false, actual_obj.get_flag(corevm::dyobj::DYOBJ_IS_IMMUTABLE));
-}
-
-// -----------------------------------------------------------------------------
-
-TEST_F(instrs_obj_unittest, TestInstrUNMUTE)
-{
-  corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();
-  m_process.push_stack(id);
-
-  corevm::runtime::instr instr { .code=0, .oprd1=0, .oprd2=0 };
-  execute_instr<corevm::runtime::instr_handler_unmute>(instr, 1);
-
-  corevm::dyobj::dyobj_id expected_id = id;
-  corevm::dyobj::dyobj_id actual_id = m_process.top_stack();
-
-  ASSERT_EQ(expected_id, actual_id);
-
-  auto &actual_obj = process::adapter(m_process).help_get_dyobj(actual_id);
-
-  ASSERT_EQ(true, actual_obj.get_flag(corevm::dyobj::DYOBJ_IS_IMMUTABLE));
+  execute_instr_and_assert_result<corevm::runtime::instr_handler_setflmute>(
+    corevm::dyobj::flags::DYOBJ_IS_IMMUTABLE);
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -868,6 +868,14 @@ TEST_F(instrs_obj_flag_unittest, TestInstrSETFLGC)
 
 // -----------------------------------------------------------------------------
 
+TEST_F(instrs_obj_flag_unittest, TestInstrSETFLDEL)
+{
+  execute_instr_and_assert_result<corevm::runtime::instr_handler_setfldel>(
+    corevm::dyobj::flags::DYOBJ_IS_INDELIBLE);
+}
+
+// -----------------------------------------------------------------------------
+
 TEST_F(instrs_obj_unittest, TestInstrMUTE)
 {
   corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();


### PR DESCRIPTION
Currently there are two instructions: `mute` and `unmute`, that toggles the `IS_IMMUTABLE` object flag on and off respectively. This patch is to design and implement a set of instructions for toggling the other object flags.

The set of instructions added are:

* `setflgc`
* `setfldel`
* `setflcall`
* `setflmute`