### PR TITLE
[COREVM-220] Fix list.__str__

### DIFF
--- a/python/src/list.py
+++ b/python/src/list.py
@@ -25,11 +25,29 @@ class list(object):
         ### END VECTOR ###
         """
 
+    def __len__(self):
+        """
+        ### BEGIN VECTOR ###
+        [ldobj, self, 0]
+        [gethndl, 0, 0]
+        [arylen, 0, 0]
+        [new, 0, 0]
+        [sethndl, 0, 0]
+        [stobj, res_, 0]
+        ### END VECTOR ###
+        """
+        return __call(int, res_)
+
     def __str__(self):
+        size = __call(self.__len__)
+        top_index = __call(size.__sub__, 1)
+        index = __call(int, 0)
         res = __call(str, '')
         __call(res.__add__, __call(str, '['))
         for item in self:
             __call(res.__add__, __call(item.__str__)) # res += str(item)
-            __call(res.__add__, __call(str, ', '))
+            if __call(index.__lt__, top_index):
+                __call(res.__add__, __call(str, ', '))
+            index = __call(index.__add__, 1)
         __call(res.__add__, __call(str, ']'))
         return res

--- a/python/tests/list.py
+++ b/python/tests/list.py
@@ -1,1 +1,4 @@
+print list([])
+print list([1])
 print list([1, 2])
+print list([1, 2, list([3,4,5])])


### PR DESCRIPTION
The current implementation of `list.__str__` returns a string with an extra comma if the list size is greater than zero. This is because the current implementation simply loops through the array and appends a comma at the end of every iteration.

This patch fixes the issue by implementing `list.__len__` to return the length of the list, so that the array traversal can keep count of the current index to make sure not to append a comma when the index reaches one less than the length of the list.