### PR TITLE
[COREVM-225] Add support for assignments on attributes

### DIFF
--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -788,9 +788,14 @@ class BytecodeGenerator(ast.NodeVisitor):
                 self.__add_instr(code, oprd1, oprd2, loc=Loc.from_node(node))
 
     def visit_Attribute(self, node):
-        # Note: ignoring ctx here
         self.visit(node.value)
-        self.__add_instr('getattr', self.__get_encoding_id(node.attr), 0, loc=Loc.from_node(node))
+        if isinstance(node.ctx, ast.Load):
+            self.__add_instr('getattr', self.__get_encoding_id(node.attr), 0, loc=Loc.from_node(node))
+        elif isinstance(node.ctx, ast.Store):
+            self.__add_instr('swap', 0, 0)
+            self.__add_instr('setattr', self.__get_encoding_id(node.attr), 0, loc=Loc.from_node(node))
+        else:
+            raise Exception('Unexpected type for node.ctx in visit_Attribute')
 
     """ ---------------------------- boolop -------------------------------- """
 

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -795,6 +795,8 @@ class BytecodeGenerator(ast.NodeVisitor):
             self.__add_instr('swap', 0, 0)
             self.__add_instr('setattr', self.__get_encoding_id(node.attr), 0, loc=Loc.from_node(node))
         else:
+            # NOTE: if this ever happens, then we have to take that type into
+            # consideration.
             raise Exception('Unexpected type for node.ctx in visit_Attribute')
 
     """ ---------------------------- boolop -------------------------------- """

--- a/python/tests/class.py
+++ b/python/tests/class.py
@@ -9,3 +9,5 @@ class MyObject(object):
 
 o = MyObject(1)
 o.run('Hello world')
+o.name = 'Will'
+print o.name

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -104,6 +104,7 @@ corevm::runtime::instr_handler_meta::instr_set[INSTR_CODE_MAX] {
   /* RSETATTRS */    { .num_oprd=1, .str="rsetattrs", .handler=std::make_shared<corevm::runtime::instr_handler_rsetattrs>() },
   /* PUTOBJ    */    { .num_oprd=0, .str="putobj",    .handler=std::make_shared<corevm::runtime::instr_handler_putobj>()    },
   /* GETOBJ    */    { .num_oprd=0, .str="getobj",    .handler=std::make_shared<corevm::runtime::instr_handler_getobj>()    },
+  /* SWAP      */    { .num_oprd=0, .str="swap",      .handler=std::make_shared<corevm::runtime::instr_handler_swap>()      },
   /* SETFLGC   */    { .num_oprd=1, .str="setflgc",   .handler=std::make_shared<corevm::runtime::instr_handler_setflgc>()   },
   /* SETFLDEL  */    { .num_oprd=1, .str="setfldel",  .handler=std::make_shared<corevm::runtime::instr_handler_setfldel>()  },
   /* SETFLCALL */    { .num_oprd=1, .str="setflcall", .handler=std::make_shared<corevm::runtime::instr_handler_setflcall>() },
@@ -1012,6 +1013,15 @@ corevm::runtime::instr_handler_getobj::execute(
     corevm::dyobj::dyobj_id>(hndl);
 
   process.push_stack(id);
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::instr_handler_swap::execute(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  process.swap_stack();
 }
 
 // -----------------------------------------------------------------------------

--- a/src/runtime/instr.h
+++ b/src/runtime/instr.h
@@ -200,6 +200,12 @@ enum instr_enum : uint32_t
   GETOBJ,
 
   /**
+   * <swap, _, _>
+   * Swaps the top two objects on top of the stack.
+   */
+  SWAP,
+
+  /**
    * <setflgc, #, _>
    * Sets the `IS_NOT_GARBAGE_COLLECTIBLE` flag on the object on top of the
    * stack.
@@ -1258,6 +1264,14 @@ public:
 // -----------------------------------------------------------------------------
 
 class instr_handler_getobj : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_swap : public instr_handler
 {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -44,6 +44,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <ostream>
 #include <stack>
 #include <stdexcept>
+#include <utility>
 #include <unordered_map>
 
 #include <setjmp.h>
@@ -349,6 +350,29 @@ corevm::runtime::process::pop_stack()
   corevm::dyobj::dyobj_id id = m_dyobj_stack.back();
   m_dyobj_stack.pop_back();
   return id;
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::process::swap_stack()
+{
+  if (m_dyobj_stack.size() < 2)
+  {
+    THROW(corevm::runtime::invalid_operation_error(
+      "Cannot swap top of object stack"));
+  }
+
+  auto itr = m_dyobj_stack.begin();
+  auto itr2 = m_dyobj_stack.begin();
+
+  std::advance(itr, m_dyobj_stack.size() - 2);
+  std::advance(itr2, m_dyobj_stack.size() - 1);
+
+  ASSERT(itr != m_dyobj_stack.end());
+  ASSERT(itr2 != m_dyobj_stack.end());
+
+  std::swap(*itr, *itr2);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -369,8 +369,10 @@ corevm::runtime::process::swap_stack()
   std::advance(itr, m_dyobj_stack.size() - 2);
   std::advance(itr2, m_dyobj_stack.size() - 1);
 
+#if __DEBUG__
   ASSERT(itr != m_dyobj_stack.end());
   ASSERT(itr2 != m_dyobj_stack.end());
+#endif
 
   std::swap(*itr, *itr2);
 }

--- a/src/runtime/process.h
+++ b/src/runtime/process.h
@@ -138,6 +138,8 @@ public:
   const corevm::dyobj::dyobj_id pop_stack()
     throw(corevm::runtime::object_stack_empty_error);
 
+  void swap_stack();
+
   void push_stack(corevm::dyobj::dyobj_id&);
 
   bool has_ntvhndl(corevm::dyobj::ntvhndl_key&);

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -852,6 +852,8 @@ TEST_F(instrs_obj_unittest, TestInstrSWAP)
   m_process.push_stack(id2);
   m_process.push_stack(id1);
 
+  ASSERT_EQ(id1, m_process.top_stack());
+
   execute_instr<corevm::runtime::instr_handler_swap>(instr, 2);
 
   corevm::dyobj::dyobj_id top_id = m_process.top_stack();

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -831,6 +831,36 @@ TEST_F(instrs_obj_unittest, TestInstrGETOBJ)
 
 // -----------------------------------------------------------------------------
 
+TEST_F(instrs_obj_unittest, TestInstrSWAP)
+{
+  corevm::dyobj::dyobj_id id1 = 1;
+  corevm::dyobj::dyobj_id id2 = 2;
+
+  corevm::runtime::instr instr {
+    .code = 0,
+    .oprd1 = 0,
+    .oprd2 = 0
+  };
+
+  ASSERT_THROW(
+    {
+      execute_instr<corevm::runtime::instr_handler_swap>(instr, 2);
+    },
+    corevm::runtime::invalid_operation_error
+  );
+
+  m_process.push_stack(id2);
+  m_process.push_stack(id1);
+
+  execute_instr<corevm::runtime::instr_handler_swap>(instr, 2);
+
+  corevm::dyobj::dyobj_id top_id = m_process.top_stack();
+
+  ASSERT_EQ(id2, top_id);
+}
+
+// -----------------------------------------------------------------------------
+
 class instrs_obj_flag_unittest : public instrs_obj_unittest
 {
 protected:

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -240,6 +240,28 @@ TEST_F(process_unittest, TestPushAndPopStack)
 
 // -----------------------------------------------------------------------------
 
+TEST_F(process_unittest, TestSwapStack)
+{
+  corevm::runtime::process process;
+
+  corevm::dyobj::dyobj_id id1 = 1;
+  corevm::dyobj::dyobj_id id2 = 2;
+
+  process.push_stack(id2);
+  process.push_stack(id1);
+
+  ASSERT_EQ(id1, process.top_stack());
+
+  process.swap_stack();
+
+  ASSERT_EQ(id2, process.top_stack());
+
+  ASSERT_EQ(id2, process.pop_stack());
+  ASSERT_EQ(id1, process.pop_stack());
+}
+
+// -----------------------------------------------------------------------------
+
 TEST_F(process_unittest, TestPushAndPopFrames)
 {
   corevm::runtime::process process;


### PR DESCRIPTION
Currently support for assignments on attributes in Python is absent. For example, the following example does not work as of now:

```
obj.name = "Will"
```