### PR TITLE
[COREVM-226] Display source file path in stack trace

### DIFF
--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -147,6 +147,7 @@ class BytecodeGenerator(ast.NodeVisitor):
     default_closure_name = '__main__'
 
     def __init__(self, options):
+        self.input_file = options.input_file
         self.output_file = options.output_file
         self.debug_mode = options.debug_mode
 
@@ -182,7 +183,7 @@ class BytecodeGenerator(ast.NodeVisitor):
             'format': self.format,
             'format-version': self.format_version,
             'target-version': self.target_version,
-            'path': '',
+            'path': self.input_file,
             'timestamp': datetime.now().strftime('%Y-%m-%dT%H:%M:%S'),
             'encoding': self.encoding,
             'author': self.author,

--- a/src/frontend/bytecode_loader_v0_1.cc
+++ b/src/frontend/bytecode_loader_v0_1.cc
@@ -115,6 +115,7 @@ corevm::frontend::bytecode_loader_v0_1::schema() const
         "\"format\","
         "\"format-version\","
         "\"target-version\","
+        "\"path\","
         "\"encoding\","
         "\"encoding_map\","
         "\"__MAIN__\""
@@ -177,12 +178,15 @@ corevm::frontend::bytecode_loader_v0_1::schema() const
 
 void
 corevm::frontend::bytecode_loader_v0_1::load(
-  const std::string& path, const JSON& content_json,
+  const std::string& path,
+  const JSON& content_json,
   corevm::runtime::process& process)
 {
-  corevm::runtime::compartment compartment(path);
-
   const JSON::object& json_object = content_json.object_items();
+
+  const std::string& source_path = json_object.at("path").string_value();
+
+  corevm::runtime::compartment compartment(source_path);
 
   // Load encoding map.
   corevm::runtime::encoding_map encoding_map;


### PR DESCRIPTION
Currently when printing the stack trace, the path of the compiled bytecode is shown. The correct behavior, however, is to show the path of the original source file.

![corevm_stack_trace_show_source_path](https://cloud.githubusercontent.com/assets/554685/7083286/971d2a4c-df14-11e4-945b-05a8b813f5b6.png)
