### PR TITLE
[COREVM-227] Fix cross-compartment object attribute mismatch

### DIFF
--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -315,6 +315,7 @@ class BytecodeGenerator(ast.NodeVisitor):
         self.current_class_name = self.current_class_name + '::' + node.name
 
         self.__add_instr('new', self.__get_dyobj_flag(['DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE']), 0)
+        self.__add_instr('setctx', 0, 0) # Need to set the ctx for attr look up.
         self.__add_instr('map', 0, 0)
         self.__add_instr('sethndl', 0, 0)
         self.__add_instr('stobj', self.__get_encoding_id(node.name), 0)

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -315,7 +315,7 @@ class BytecodeGenerator(ast.NodeVisitor):
         self.current_class_name = self.current_class_name + '::' + node.name
 
         self.__add_instr('new', self.__get_dyobj_flag(['DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE']), 0)
-        self.__add_instr('setctx', 0, 0) # Need to set the ctx for attr look up.
+        self.__add_instr('setctx', 0, 0)
         self.__add_instr('map', 0, 0)
         self.__add_instr('sethndl', 0, 0)
         self.__add_instr('stobj', self.__get_encoding_id(node.name), 0)

--- a/python/src/__builtin__.py
+++ b/python/src/__builtin__.py
@@ -13,8 +13,8 @@ class object:
         ### BEGIN VECTOR ###
         [new, 0, 0]
         [ldobj, cls, 0]
-        [gethndl, 0, 0]
         [setattr, __class__, 0]
+        [ldobj, cls, 0]
         [setattrs, 1, 1]
         [rsetattrs, im_self, 0]
         ### END VECTOR ###

--- a/src/dyobj/util.cc
+++ b/src/dyobj/util.cc
@@ -1,0 +1,37 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Yanzheng Li
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+#include "util.h"
+
+#include <functional>
+
+
+// -----------------------------------------------------------------------------
+
+corevm::dyobj::attr_key
+corevm::dyobj::hash_attr_str(const std::string& attr_str)
+{
+  static std::hash<std::string> hasher;
+  return hasher(attr_str);
+}
+
+// -----------------------------------------------------------------------------

--- a/src/dyobj/util.h
+++ b/src/dyobj/util.h
@@ -1,0 +1,46 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Yanzheng Li
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+#ifndef COREVM_DYOBJ_UTIL_H_
+#define COREVM_DYOBJ_UTIL_H_
+
+#include "common.h"
+#include <string>
+
+
+namespace corevm {
+
+
+namespace dyobj {
+
+
+attr_key
+hash_attr_str(const std::string&);
+
+
+}; /* end namespace dyobj */
+
+
+}; /* end namespace corevm */
+
+
+#endif /* COREVM_DYOBJ_UTIL_H_ */

--- a/src/include.mk
+++ b/src/include.mk
@@ -30,6 +30,7 @@ COREVM_DIR=corevm
 SOURCES += $(TOP_DIR)/$(SRC)/$(MEMORY)/sequential_allocation_scheme.cc
 
 SOURCES += $(TOP_DIR)/$(SRC)/$(DYOBJ)/flags.cc
+SOURCES += $(TOP_DIR)/$(SRC)/$(DYOBJ)/util.cc
 
 SOURCES += $(TOP_DIR)/$(SRC)/$(GC)/mark_and_sweep_garbage_collection_scheme.cc
 SOURCES += $(TOP_DIR)/$(SRC)/$(GC)/reference_count_garbage_collection_scheme.cc

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -41,11 +41,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // -----------------------------------------------------------------------------
 
+
 namespace corevm {
 
 
 namespace runtime {
 
+
+// -----------------------------------------------------------------------------
 
 std::ostream& operator<<(
   std::ostream& ost, const corevm::runtime::instr& instr)
@@ -69,11 +72,51 @@ bool operator==(const instr& lhs, const instr& rhs)
     lhs.oprd2 == rhs.oprd2;
 }
 
+// -----------------------------------------------------------------------------
+
+static corevm::dyobj::attr_key
+get_attr_key(
+  corevm::runtime::process& process,
+  corevm::runtime::compartment_id compartment_id,
+  uint64_t str_key)
+{
+  corevm::runtime::compartment *compartment=nullptr;
+  process.get_compartment(compartment_id, &compartment);
+
+#if __DEBUG__
+  ASSERT(compartment);
+#endif
+
+  std::string attr_str;
+  compartment->get_encoding_string(str_key, &attr_str);
+
+  corevm::dyobj::attr_key attr_key = std::hash<std::string>()(attr_str);
+
+  return attr_key;
+}
+
+// -----------------------------------------------------------------------------
+
+static corevm::dyobj::attr_key
+get_attr_key_from_current_compartment(
+  corevm::runtime::process& process,
+  uint64_t str_key)
+{
+  const corevm::runtime::frame& frame = process.top_frame();
+
+  corevm::runtime::compartment *compartment=nullptr;
+  process.get_compartment(frame.closure_ctx().compartment_id, &compartment);
+
+  return get_attr_key(process, frame.closure_ctx().compartment_id, str_key);
+}
+
+// -----------------------------------------------------------------------------
 
 } /* end namespace runtime */
 
 
 } /* end namespace corevm */
+
 
 // -----------------------------------------------------------------------------
 
@@ -537,7 +580,9 @@ void
 corevm::runtime::instr_handler_getattr::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::dyobj::attr_key attr_key = static_cast<corevm::dyobj::attr_key>(instr.oprd1);
+  uint64_t str_key = static_cast<uint64_t>(instr.oprd1);
+  corevm::dyobj::attr_key attr_key = get_attr_key_from_current_compartment(
+    process, str_key);
 
   corevm::dyobj::dyobj_id id = process.pop_stack();
   auto &obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
@@ -552,7 +597,9 @@ void
 corevm::runtime::instr_handler_setattr::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::dyobj::attr_key attr_key = static_cast<corevm::dyobj::attr_key>(instr.oprd1);
+  uint64_t str_key = static_cast<uint64_t>(instr.oprd1);
+  corevm::dyobj::attr_key attr_key = get_attr_key_from_current_compartment(
+    process, str_key);
 
   corevm::dyobj::dyobj_id attr_id= process.pop_stack();
   corevm::dyobj::dyobj_id target_id = process.pop_stack();
@@ -901,12 +948,15 @@ void
 corevm::runtime::instr_handler_setattrs::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
+  corevm::dyobj::dyobj_id src_id = process.pop_stack();
+  auto& src_obj = corevm::runtime::process::adapter(process).help_get_dyobj(src_id);
+
   corevm::dyobj::dyobj_id id = process.top_stack();
   auto& obj = corevm::runtime::process::adapter(process).help_get_dyobj(id);
 
   corevm::runtime::frame& frame = process.top_frame();
 
-  corevm::types::native_type_handle hndl = frame.pop_eval_stack();
+  corevm::types::native_type_handle hndl = process.get_ntvhndl(src_obj.ntvhndl_key());//frame.pop_eval_stack();
   corevm::types::native_type_handle res;
 
   corevm::types::interface_to_map(hndl, res);
@@ -920,7 +970,9 @@ corevm::runtime::instr_handler_setattrs::execute(
 
   for (auto itr = map.begin(); itr != map.end(); ++itr)
   {
-    corevm::dyobj::attr_key attr_key = static_cast<corevm::dyobj::attr_key>(itr->first);
+    uint64_t str_key = static_cast<uint64_t>(itr->first);
+    corevm::dyobj::attr_key attr_key = get_attr_key(process, src_obj.closure_ctx().compartment_id, str_key);
+
     corevm::dyobj::dyobj_id attr_id = static_cast<corevm::dyobj::dyobj_id>(itr->second);
 
     auto &attr_obj = corevm::runtime::process::adapter(process).help_get_dyobj(attr_id);
@@ -957,12 +1009,14 @@ void
 corevm::runtime::instr_handler_rsetattrs::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  corevm::dyobj::attr_key attr_key = static_cast<corevm::dyobj::attr_key>(instr.oprd1);
+  uint64_t str_key = static_cast<uint64_t>(instr.oprd1);
+  corevm::dyobj::attr_key attr_key = get_attr_key_from_current_compartment(
+    process, str_key);
+
+  corevm::runtime::frame& frame = process.top_frame();
 
   corevm::dyobj::dyobj_id attr_id = process.top_stack();
   auto& attr_obj = corevm::runtime::process::adapter(process).help_get_dyobj(attr_id);
-
-  corevm::runtime::frame& frame = process.top_frame();
 
   corevm::types::native_type_handle hndl = frame.pop_eval_stack();
   corevm::types::native_type_handle res;

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -956,7 +956,7 @@ corevm::runtime::instr_handler_setattrs::execute(
 
   corevm::runtime::frame& frame = process.top_frame();
 
-  corevm::types::native_type_handle hndl = process.get_ntvhndl(src_obj.ntvhndl_key());//frame.pop_eval_stack();
+  corevm::types::native_type_handle hndl = process.get_ntvhndl(src_obj.ntvhndl_key());
   corevm::types::native_type_handle res;
 
   corevm::types::interface_to_map(hndl, res);
@@ -971,7 +971,8 @@ corevm::runtime::instr_handler_setattrs::execute(
   for (auto itr = map.begin(); itr != map.end(); ++itr)
   {
     uint64_t str_key = static_cast<uint64_t>(itr->first);
-    corevm::dyobj::attr_key attr_key = get_attr_key(process, src_obj.closure_ctx().compartment_id, str_key);
+    corevm::dyobj::attr_key attr_key = get_attr_key(
+      process, src_obj.closure_ctx().compartment_id, str_key);
 
     corevm::dyobj::dyobj_id attr_id = static_cast<corevm::dyobj::dyobj_id>(itr->second);
 
@@ -979,8 +980,11 @@ corevm::runtime::instr_handler_setattrs::execute(
 
     if (should_clone)
     {
-      auto cloned_attr_id = corevm::runtime::process::adapter(process).help_create_dyobj();
-      auto& cloned_attr_obj = corevm::runtime::process::adapter(process).help_get_dyobj(cloned_attr_id);
+      auto cloned_attr_id =
+        corevm::runtime::process::adapter(process).help_create_dyobj();
+
+      auto& cloned_attr_obj =
+        corevm::runtime::process::adapter(process).help_get_dyobj(cloned_attr_id);
 
       cloned_attr_obj.copy_from(attr_obj);
       cloned_attr_obj.manager().on_setattr();

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -78,14 +78,23 @@ static corevm::dyobj::attr_key
 get_attr_key(
   corevm::runtime::process& process,
   corevm::runtime::compartment_id compartment_id,
-  uint64_t str_key)
+  uint64_t str_key,
+  bool from_current_compartment=false)
 {
   corevm::runtime::compartment *compartment=nullptr;
   process.get_compartment(compartment_id, &compartment);
 
-#if __DEBUG__
-  ASSERT(compartment);
-#endif
+  if (!compartment)
+  {
+    if (!from_current_compartment)
+    {
+      THROW(corevm::runtime::compartment_not_found_error(compartment_id));
+    }
+    else
+    {
+      ASSERT(compartment);
+    }
+  }
 
   std::string attr_str;
   compartment->get_encoding_string(str_key, &attr_str);
@@ -104,10 +113,8 @@ get_attr_key_from_current_compartment(
 {
   const corevm::runtime::frame& frame = process.top_frame();
 
-  corevm::runtime::compartment *compartment=nullptr;
-  process.get_compartment(frame.closure_ctx().compartment_id, &compartment);
-
-  return get_attr_key(process, frame.closure_ctx().compartment_id, str_key);
+  return get_attr_key(
+    process, frame.closure_ctx().compartment_id, str_key, true);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -24,6 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "process.h"
 #include "corevm/macros.h"
+#include "dyobj/util.h"
 #include "types/interfaces.h"
 #include "types/types.h"
 
@@ -99,7 +100,7 @@ get_attr_key(
   std::string attr_str;
   compartment->get_encoding_string(str_key, &attr_str);
 
-  corevm::dyobj::attr_key attr_key = std::hash<std::string>()(attr_str);
+  corevm::dyobj::attr_key attr_key = corevm::dyobj::hash_attr_str(attr_str);
 
   return attr_key;
 }

--- a/src/runtime/instr.h
+++ b/src/runtime/instr.h
@@ -169,9 +169,10 @@ enum instr_enum : uint32_t
 
   /**
    * <setattrs, #, #>
-   * Converts the native type handle on top of the eval stack to a native map,
-   * and use its key-value pairs as attribute name-value pairs to set on the
-   * object on the top of the stack. The first operand is a boolean value
+   * Pops off the object on top of the stack, and convert its native type
+   * handle to a native map.
+   * Then use its key-value pairs as attribute name-value pairs to set on the
+   * next object on the top of the stack. The first operand is a boolean value
    * specifying whether each mapped object should be cloned before set on the
    * target object. The second operand is a boolean value indicating if
    * the native map values should be overriden with the cloned object IDs.

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -429,7 +429,7 @@ corevm::runtime::process::has_ntvhndl(corevm::dyobj::ntvhndl_key& key)
 // -----------------------------------------------------------------------------
 
 corevm::types::native_type_handle&
-corevm::runtime::process::get_ntvhndl(corevm::dyobj::ntvhndl_key& key)
+corevm::runtime::process::get_ntvhndl(corevm::dyobj::ntvhndl_key key)
   throw(corevm::runtime::native_type_handle_not_found_error)
 {
   return m_ntvhndl_pool.at(key);
@@ -452,7 +452,7 @@ corevm::runtime::process::insert_ntvhndl(corevm::types::native_type_handle& hndl
 // -----------------------------------------------------------------------------
 
 void
-corevm::runtime::process::erase_ntvhndl(corevm::dyobj::ntvhndl_key& key)
+corevm::runtime::process::erase_ntvhndl(corevm::dyobj::ntvhndl_key key)
   throw(corevm::runtime::native_type_handle_deletion_error)
 {
   if (key == corevm::dyobj::NONESET_NTVHNDL_KEY)

--- a/src/runtime/process.h
+++ b/src/runtime/process.h
@@ -144,13 +144,13 @@ public:
 
   bool has_ntvhndl(corevm::dyobj::ntvhndl_key&);
 
-  corevm::types::native_type_handle& get_ntvhndl(corevm::dyobj::ntvhndl_key&)
+  corevm::types::native_type_handle& get_ntvhndl(corevm::dyobj::ntvhndl_key)
     throw(corevm::runtime::native_type_handle_not_found_error);
 
   corevm::dyobj::ntvhndl_key insert_ntvhndl(corevm::types::native_type_handle&)
     throw(corevm::runtime::native_type_handle_insertion_error);
 
-  void erase_ntvhndl(corevm::dyobj::ntvhndl_key&)
+  void erase_ntvhndl(corevm::dyobj::ntvhndl_key)
     throw(corevm::runtime::native_type_handle_deletion_error);
 
   const corevm::runtime::instr_addr pc() const;

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -21,6 +21,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *******************************************************************************/
 #include "dyobj/flags.h"
+#include "dyobj/util.h"
 #include "runtime/closure.h"
 #include "runtime/common.h"
 #include "runtime/invocation_ctx.h"
@@ -236,7 +237,7 @@ TEST_F(instrs_obj_unittest, TestInstrGETATTR)
   corevm::dyobj::dyobj_id id2 = process::adapter(m_process).help_create_dyobj();
 
   auto &obj = process::adapter(m_process).help_get_dyobj(id1);
-  corevm::dyobj::attr_key attr_key = std::hash<std::string>()(attr_str);
+  corevm::dyobj::attr_key attr_key = corevm::dyobj::hash_attr_str(attr_str);
   obj.putattr(attr_key, id2);
   m_process.push_stack(id1);
 
@@ -289,7 +290,7 @@ TEST_F(instrs_obj_unittest, TestInstrSETATTR)
 
   auto &obj = process::adapter(m_process).help_get_dyobj(actual_id);
 
-  corevm::dyobj::attr_key attr_key = std::hash<std::string>()(attr_str);
+  corevm::dyobj::attr_key attr_key = corevm::dyobj::hash_attr_str(attr_str);
 
   ASSERT_TRUE(obj.hasattr(attr_key));
 
@@ -738,9 +739,9 @@ TEST_F(instrs_obj_unittest, TestInstrSETATTRS)
   compartment.set_encoding_map(encoding_map);
   m_process.insert_compartment(compartment);
 
-  corevm::dyobj::attr_key attr_key1 = std::hash<std::string>()(attr_str1);
-  corevm::dyobj::attr_key attr_key2 = std::hash<std::string>()(attr_str2);
-  corevm::dyobj::attr_key attr_key3 = std::hash<std::string>()(attr_str3);
+  corevm::dyobj::attr_key attr_key1 = corevm::dyobj::hash_attr_str(attr_str1);
+  corevm::dyobj::attr_key attr_key2 = corevm::dyobj::hash_attr_str(attr_str2);
+  corevm::dyobj::attr_key attr_key3 = corevm::dyobj::hash_attr_str(attr_str3);
 
   corevm::runtime::closure_ctx ctx {
     .compartment_id = compartment_id,
@@ -816,7 +817,7 @@ TEST_F(instrs_obj_unittest, TestInstrRSETATTRS)
 
   m_process.push_frame(frame);
 
-  corevm::dyobj::attr_key attr_key = std::hash<std::string>()(attr_str);
+  corevm::dyobj::attr_key attr_key = corevm::dyobj::hash_attr_str(attr_str);
 
   corevm::runtime::instr instr {
     .code = 0,

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -211,13 +211,32 @@ TEST_F(instrs_obj_unittest, TestInstrSTOBJ)
 
 TEST_F(instrs_obj_unittest, TestInstrGETATTR)
 {
-  corevm::dyobj::attr_key attr_key = 333;
-  corevm::runtime::instr instr { .code=0, .oprd1=attr_key, .oprd2=0 };
+  corevm::runtime::compartment_id compartment_id = 0;
+  corevm::runtime::compartment compartment(DUMMY_PATH);
+
+  uint64_t attr_str_key = 333;
+  const std::string attr_str = "Hello world";
+
+  corevm::runtime::encoding_map encoding_table {
+    { attr_str_key, attr_str }
+  };
+
+  compartment.set_encoding_map(encoding_table);
+  m_process.insert_compartment(compartment);
+
+  corevm::runtime::closure_ctx ctx {
+    .compartment_id = compartment_id,
+    .closure_id = corevm::runtime::NONESET_CLOSURE_ID,
+  };
+  m_process.emplace_frame(ctx);
+
+  corevm::runtime::instr instr { .code=0, .oprd1=attr_str_key, .oprd2=0 };
 
   corevm::dyobj::dyobj_id id1 = process::adapter(m_process).help_create_dyobj();
   corevm::dyobj::dyobj_id id2 = process::adapter(m_process).help_create_dyobj();
 
   auto &obj = process::adapter(m_process).help_get_dyobj(id1);
+  corevm::dyobj::attr_key attr_key = std::hash<std::string>()(attr_str);
   obj.putattr(attr_key, id2);
   m_process.push_stack(id1);
 
@@ -233,8 +252,27 @@ TEST_F(instrs_obj_unittest, TestInstrGETATTR)
 
 TEST_F(instrs_obj_unittest, TestInstrSETATTR)
 {
-  corevm::dyobj::attr_key attr_key = 789;
-  corevm::runtime::instr instr { .code=0, .oprd1=attr_key, .oprd2=0 };
+  corevm::runtime::compartment_id compartment_id = 0;
+  corevm::runtime::compartment compartment(DUMMY_PATH);
+
+  uint64_t attr_str_key = 333;
+  const std::string attr_str = "Hello world";
+
+  corevm::runtime::encoding_map encoding_table {
+    { attr_str_key, attr_str }
+  };
+
+  compartment.set_encoding_map(encoding_table);
+  m_process.insert_compartment(compartment);
+
+  corevm::runtime::closure_ctx ctx {
+    .compartment_id = compartment_id,
+    .closure_id = corevm::runtime::NONESET_CLOSURE_ID,
+  };
+
+  m_process.emplace_frame(ctx);
+
+  corevm::runtime::instr instr { .code=0, .oprd1=attr_str_key, .oprd2=0 };
 
   corevm::dyobj::dyobj_id id1 = process::adapter(m_process).help_create_dyobj();
   corevm::dyobj::dyobj_id id2 = process::adapter(m_process).help_create_dyobj();
@@ -250,6 +288,8 @@ TEST_F(instrs_obj_unittest, TestInstrSETATTR)
   ASSERT_EQ(expected_id, actual_id);
 
   auto &obj = process::adapter(m_process).help_get_dyobj(actual_id);
+
+  corevm::dyobj::attr_key attr_key = std::hash<std::string>()(attr_str);
 
   ASSERT_TRUE(obj.hasattr(attr_key));
 
@@ -679,21 +719,43 @@ TEST_F(instrs_obj_unittest, TestInstrSETATTRS)
     { 3, static_cast<corevm::types::native_map_mapped_type>(id3) },
   };
 
+  auto ntvhndl_key = m_process.insert_ntvhndl(hndl);
+
   corevm::runtime::compartment_id compartment_id = 0;
   corevm::runtime::closure_id closure_id = 10;
+
+  corevm::runtime::compartment compartment(DUMMY_PATH);
+
+  const std::string attr_str1 = "__init__";
+  const std::string attr_str2 = "__len__";
+  const std::string attr_str3 = "__iter__";
+
+  corevm::runtime::encoding_map encoding_map {
+    { 1, attr_str1 },
+    { 2, attr_str2 },
+    { 3, attr_str3 },
+  };
+  compartment.set_encoding_map(encoding_map);
+  m_process.insert_compartment(compartment);
+
+  corevm::dyobj::attr_key attr_key1 = std::hash<std::string>()(attr_str1);
+  corevm::dyobj::attr_key attr_key2 = std::hash<std::string>()(attr_str2);
+  corevm::dyobj::attr_key attr_key3 = std::hash<std::string>()(attr_str3);
 
   corevm::runtime::closure_ctx ctx {
     .compartment_id = compartment_id,
     .closure_id = closure_id
   };
 
-  corevm::runtime::frame frame(ctx);
-  frame.push_eval_stack(hndl);
+  corevm::dyobj::dyobj_id dst_id = process::adapter(m_process).help_create_dyobj();
+  m_process.push_stack(dst_id);
 
-  corevm::dyobj::dyobj_id id = process::adapter(m_process).help_create_dyobj();
-  m_process.push_stack(id);
+  corevm::dyobj::dyobj_id src_id = process::adapter(m_process).help_create_dyobj();
+  auto& src_obj = process::adapter(m_process).help_get_dyobj(src_id);
+  src_obj.set_ntvhndl_key(ntvhndl_key);
+  src_obj.set_closure_ctx(ctx);
 
-  m_process.push_frame(frame);
+  m_process.push_stack(src_id);
 
   corevm::runtime::instr instr {
     .code = 0,
@@ -704,11 +766,14 @@ TEST_F(instrs_obj_unittest, TestInstrSETATTRS)
   execute_instr<corevm::runtime::instr_handler_setattrs>(instr, 1);
 
   corevm::dyobj::dyobj_id actual_id = m_process.top_stack();
+
+  ASSERT_EQ(dst_id, actual_id);
+
   auto& obj = process::adapter(m_process).help_get_dyobj(actual_id);
 
-  ASSERT_EQ(id1, obj.getattr(1));
-  ASSERT_EQ(id2, obj.getattr(2));
-  ASSERT_EQ(id3, obj.getattr(3));
+  ASSERT_EQ(id1, obj.getattr(attr_key1));
+  ASSERT_EQ(id2, obj.getattr(attr_key2));
+  ASSERT_EQ(id3, obj.getattr(attr_key3));
 }
 
 // -----------------------------------------------------------------------------
@@ -726,11 +791,21 @@ TEST_F(instrs_obj_unittest, TestInstrRSETATTRS)
   };
 
   corevm::runtime::compartment_id compartment_id = 0;
-  corevm::runtime::closure_id closure_id = 10;
+
+  uint64_t attr_str_key = 333;
+  const std::string attr_str = "Hello world";
+
+  corevm::runtime::encoding_map encoding_table {
+    { attr_str_key, attr_str }
+  };
+
+  corevm::runtime::compartment compartment(DUMMY_PATH);
+  compartment.set_encoding_map(encoding_table);
+  m_process.insert_compartment(compartment);
 
   corevm::runtime::closure_ctx ctx {
     .compartment_id = compartment_id,
-    .closure_id = closure_id
+    .closure_id = corevm::runtime::NONESET_CLOSURE_ID,
   };
 
   corevm::runtime::frame frame(ctx);
@@ -741,11 +816,11 @@ TEST_F(instrs_obj_unittest, TestInstrRSETATTRS)
 
   m_process.push_frame(frame);
 
-  corevm::dyobj::attr_key attr = 1;
+  corevm::dyobj::attr_key attr_key = std::hash<std::string>()(attr_str);
 
   corevm::runtime::instr instr {
     .code = 0,
-    .oprd1= static_cast<corevm::runtime::instr_oprd>(attr),
+    .oprd1= static_cast<corevm::runtime::instr_oprd>(attr_str_key),
     .oprd2 = 0
   };
 
@@ -755,9 +830,9 @@ TEST_F(instrs_obj_unittest, TestInstrRSETATTRS)
   auto& obj2 = process::adapter(m_process).help_get_dyobj(id2);
   auto& obj3 = process::adapter(m_process).help_get_dyobj(id3);
 
-  ASSERT_EQ(id, obj1.getattr(attr));
-  ASSERT_EQ(id, obj2.getattr(attr));
-  ASSERT_EQ(id, obj3.getattr(attr));
+  ASSERT_EQ(id, obj1.getattr(attr_key));
+  ASSERT_EQ(id, obj2.getattr(attr_key));
+  ASSERT_EQ(id, obj3.getattr(attr_key));
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Previous to this patch, static attributes on objects are assigned with compiler generated IDs at compile time. This had two problems: 1) The attribute keys were not cross-compartment compatible, and 2) this did not work for dynamic attributes.

This patch encompasses a fix to address these two issues. Specifically, object attribute keys are now the hash of the attribute strings. For static attributes during compile time, the attribute keys specified in instructions such as `getattr` and `setattr` still point to the attribute string names in the encoding map of each compartment. However, the attribute name strings are hashed at runtime, and the hash values are used as attribute keys when interacting with objects.