### PR TITLE
[COREVM-231] Fix Makefile to not archive object files from tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ $(BUILD_DIR)/%.o: $(TOP_DIR)/%.cc
 
 $(LIBCOREVM): $(OBJECTS)
 	mkdir -p $(@D)
-	@find . -name "*.o" | xargs $(AR) $(ARFLAGS) $(LIBCOREVM)
+	@find $(BUILD_DIR)/$(SRC) -name "*.o" | xargs $(AR) $(ARFLAGS) $(LIBCOREVM)
 	@echo "\033[35mGenerated $(LIBCOREVM)\033[0m"
 
 


### PR DESCRIPTION
Currently when building `libcorevm.a` or `coreVM`, it's possible for the object files associated with unit tests to be collected, archived, and ultimately linked to produce the binares. This is because, currently in the Makefile, the command below is used to archive all the object files:

```
@find . -name "*.o" | xargs $(AR) $(ARFLAGS) $(LIBCOREVM)
```

This patch fixes this issue.