### PR TITLE
[COREVM-233] Nested functions and lambdas not working when returned

### DIFF
--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -319,18 +319,18 @@ class BytecodeGenerator(ast.NodeVisitor):
     """ ----------------------------- stmt --------------------------------- """
 
     def visit_FunctionDef(self, node):
-        # step in
+        # Step in.
         self.current_function_name = self.current_function_name + '::' + node.name
-        name = self.current_class_name + '.' + self.current_function_name
+        closure_name = self.current_class_name + '.' + self.current_function_name
 
-        self.closure_map[name] = Closure(
+        self.closure_map[closure_name] = Closure(
             node.name,
-            name,
+            closure_name,
             self.current_closure_name,
             self.closure_map[self.current_closure_name].closure_id
         )
 
-        self.current_closure_name = name
+        self.current_closure_name = closure_name
 
         # Off-load arguments.
         self.visit(node.args)
@@ -342,14 +342,14 @@ class BytecodeGenerator(ast.NodeVisitor):
         # Explicit return.
         self.__add_instr('rtrn', 0, 0)
 
-        # step out
+        # Step out.
         self.current_closure_name = self.closure_map[self.current_closure_name].parent_name
         self.current_function_name = '::'.join(self.current_function_name.split('::')[:-1])
 
         # In the outer closure, set the closure id on the object
 
         self.__add_instr('new', self.__get_dyobj_flag(['DYOBJ_IS_NOT_GARBAGE_COLLECTIBLE']), 0)
-        self.__add_instr('setctx', self.closure_map[name].closure_id, 0)
+        self.__add_instr('setctx', self.closure_map[closure_name].closure_id, 0)
         self.__add_instr('ldobj', self.__get_encoding_id('object'), 0)
         self.__add_instr('setattr', self.__get_encoding_id('__class__'), 0)
 

--- a/python/python_compiler.py
+++ b/python/python_compiler.py
@@ -208,6 +208,7 @@ class BytecodeGenerator(ast.NodeVisitor):
 
         # states
         self.current_class_name = ''
+        self.current_function_name = ''
         self.try_except_state = TryExceptState()
         self.continue_stmt_vector_lengths = []
         self.break_stmt_vector_lengths = []
@@ -319,7 +320,8 @@ class BytecodeGenerator(ast.NodeVisitor):
 
     def visit_FunctionDef(self, node):
         # step in
-        name = self.__mingle_name(node.name)
+        self.current_function_name = self.current_function_name + '::' + node.name
+        name = self.current_class_name + '.' + self.current_function_name
 
         self.closure_map[name] = Closure(
             node.name,
@@ -342,6 +344,7 @@ class BytecodeGenerator(ast.NodeVisitor):
 
         # step out
         self.current_closure_name = self.closure_map[self.current_closure_name].parent_name
+        self.current_function_name = '::'.join(self.current_function_name.split('::')[:-1])
 
         # In the outer closure, set the closure id on the object
 

--- a/python/tests/call.py
+++ b/python/tests/call.py
@@ -25,11 +25,13 @@ print 'Starting...'
 main(int(1))
 print 'Done!'
 
+## -----------------------------------------------------------------------------
 
 func = lambda x: x * 2
 
 print func(1)
 
+## -----------------------------------------------------------------------------
 
 def lambda_caller(arg):
     def inner(arg):
@@ -37,11 +39,28 @@ def lambda_caller(arg):
         return func(arg)
     return inner(arg)
 
-
 print lambda_caller(3)
 
+## -----------------------------------------------------------------------------
 
-print 'I can do math' if lambda_caller(1) else 'I suck at math'
+def lambda_caller2():
+    def inner2(arg):
+        func = lambda arg: arg ** arg
+        return func(arg)
+    return inner2
 
+print lambda_caller2()(5)
 
-print 'Nested if-esle WTF :D' if (True if 1 + 1 == 2 else False) else 'This is too confusing @__@'
+## -----------------------------------------------------------------------------
+
+def lambda_caller3():
+    def inner3(arg):
+        def inner4(arg):
+            func = lambda arg: arg ** arg
+            return func(arg)
+        return inner4(arg) * arg
+    return inner3
+
+print lambda_caller3()(5)
+
+## -----------------------------------------------------------------------------

--- a/python/tests/exprs.py
+++ b/python/tests/exprs.py
@@ -1,0 +1,3 @@
+print 'Nested if-esle WTF :D' if (True if 1 + 1 == 2 else False) else 'This is too confusing @__@'
+
+## -----------------------------------------------------------------------------

--- a/python/tests/try_except.py
+++ b/python/tests/try_except.py
@@ -131,6 +131,19 @@ except AnotherException:
 
 ## -----------------------------------------------------------------------------
 
+def parent():
+    def inner2():
+        raise Exception()
+
+    return inner2
+
+try:
+    parent()()
+except Exception:
+    print 'Exception from nested function caught.'
+
+## -----------------------------------------------------------------------------
+
 # TODO: Run this test when inheritance is supported.
 #try:
 #    raise YetAnotherException()

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -120,6 +120,95 @@ get_attr_key_from_current_compartment(
 
 // -----------------------------------------------------------------------------
 
+/**
+ * Given a starting closure context, find the existing frame associated with it,
+ * following the closure tree.
+ *
+ * Returns a pointer that points to the frame, if found. Returns a null pointer
+ * otherwise.
+ */
+static
+corevm::runtime::frame* find_frame_by_ctx(
+  corevm::runtime::closure_ctx ctx,
+  corevm::runtime::compartment* compartment,
+  corevm::runtime::process& process)
+{
+  ASSERT(compartment);
+
+  corevm::runtime::frame* frame = nullptr;
+
+  while (!frame)
+  {
+    bool res = process.get_frame_by_closure_ctx(ctx, &frame);
+
+    if (res)
+    {
+      ASSERT(frame);
+      break;
+    }
+
+    corevm::runtime::closure closure = compartment->get_closure_by_id(ctx.closure_id);
+    ctx.closure_id = closure.parent_id;
+
+    if (ctx.closure_id == corevm::runtime::NONESET_CLOSURE_ID)
+    {
+      THROW(corevm::runtime::local_variable_not_found_error());
+    }
+  }
+
+  return frame;
+}
+
+// -----------------------------------------------------------------------------
+
+/**
+ * Given a pointer to a starting frame, find the existing frame associated with
+ * the parent of the given frame's closure context.
+ *
+ * Returns a pointer that points to the frame, if found. Returns a null pointer
+ * otherwise.
+ */
+static
+corevm::runtime::frame* find_parent_frame_in_process(
+  corevm::runtime::frame* frame_ptr,
+  corevm::runtime::process& process)
+{
+  ASSERT(frame_ptr);
+
+  corevm::runtime::compartment_id compartment_id = frame_ptr->closure_ctx().compartment_id;
+  corevm::runtime::compartment* compartment = nullptr;
+
+  process.get_compartment(compartment_id, &compartment);
+
+  if (!compartment)
+  {
+    THROW(corevm::runtime::compartment_not_found_error(compartment_id));
+  }
+
+  corevm::runtime::closure_id closure_id = frame_ptr->closure_ctx().closure_id;
+  corevm::runtime::closure closure = compartment->get_closure_by_id(closure_id);
+
+  corevm::runtime::closure_id parent_closure_id = closure.parent_id;
+
+  ASSERT(closure.id != closure.parent_id);
+
+  if (parent_closure_id == corevm::runtime::NONESET_CLOSURE_ID)
+  {
+    THROW(corevm::runtime::local_variable_not_found_error());
+  }
+
+  closure_ctx ctx {
+    .compartment_id = compartment_id,
+    .closure_id = parent_closure_id
+  };
+
+  frame_ptr = find_frame_by_ctx(ctx, compartment, process);
+
+  return frame_ptr;
+}
+
+// -----------------------------------------------------------------------------
+
 } /* end namespace runtime */
 
 
@@ -518,6 +607,7 @@ corevm::runtime::instr_handler_new::execute(
 
 // -----------------------------------------------------------------------------
 
+
 void
 corevm::runtime::instr_handler_ldobj::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
@@ -529,38 +619,12 @@ corevm::runtime::instr_handler_ldobj::execute(
 
   while (!frame_ptr->has_visible_var(key))
   {
-    corevm::runtime::compartment_id compartment_id = frame_ptr->closure_ctx().compartment_id;
-    corevm::runtime::compartment* compartment = nullptr;
+    frame_ptr = find_parent_frame_in_process(frame_ptr, process);
 
-    process.get_compartment(compartment_id, &compartment);
-
-    if (!compartment)
-    {
-      THROW(corevm::runtime::compartment_not_found_error(compartment_id));
-    }
-
-    corevm::runtime::closure_id closure_id = frame_ptr->closure_ctx().closure_id;
-    corevm::runtime::closure closure = compartment->get_closure_by_id(closure_id);
-
-    corevm::runtime::closure_id parent_closure_id = closure.parent_id;
-
-    if (parent_closure_id == corevm::runtime::NONESET_CLOSURE_ID)
+    if (!frame_ptr)
     {
       THROW(corevm::runtime::local_variable_not_found_error());
     }
-
-    closure_ctx ctx {
-      .compartment_id = compartment_id,
-      .closure_id = parent_closure_id
-    };
-
-    process.get_frame_by_closure_ctx(ctx, &frame_ptr);
-
-    // Theoretically, the pointer that points to the frame that's
-    // associated with the parent closure should exist.
-#if __DEBUG__
-    ASSERT(frame_ptr);
-#endif
   }
 
   auto id = frame_ptr->get_visible_var(key);
@@ -674,38 +738,12 @@ corevm::runtime::instr_handler_ldobj2::execute(
 
   while (!frame_ptr->has_invisible_var(key))
   {
-    corevm::runtime::compartment_id compartment_id = frame_ptr->closure_ctx().compartment_id;
-    corevm::runtime::compartment* compartment = nullptr;
+    frame_ptr = find_parent_frame_in_process(frame_ptr, process);
 
-    process.get_compartment(compartment_id, &compartment);
-
-    if (!compartment)
-    {
-      THROW(corevm::runtime::compartment_not_found_error(compartment_id));
-    }
-
-    corevm::runtime::closure_id closure_id = frame_ptr->closure_ctx().closure_id;
-    corevm::runtime::closure closure = compartment->get_closure_by_id(closure_id);
-
-    corevm::runtime::closure_id parent_closure_id = closure.parent_id;
-
-    if (parent_closure_id == corevm::runtime::NONESET_CLOSURE_ID)
+    if (!frame_ptr)
     {
       THROW(corevm::runtime::local_variable_not_found_error());
     }
-
-    closure_ctx ctx {
-      .compartment_id = compartment_id,
-      .closure_id = parent_closure_id
-    };
-
-    process.get_frame_by_closure_ctx(ctx, &frame_ptr);
-
-    // Theoretically, the pointer that points to the frame that's
-    // associated with the parent closure should exist.
-#if __DEBUG__
-    ASSERT(frame_ptr);
-#endif
   }
 
   auto id = frame_ptr->get_invisible_var(key);
@@ -911,38 +949,12 @@ corevm::runtime::instr_handler_cldobj::execute(
 
   while (!frame_ptr->has_visible_var(key))
   {
-    corevm::runtime::compartment_id compartment_id = frame_ptr->closure_ctx().compartment_id;
-    corevm::runtime::compartment* compartment = nullptr;
+    frame_ptr = find_parent_frame_in_process(frame_ptr, process);
 
-    process.get_compartment(compartment_id, &compartment);
-
-    if (!compartment)
-    {
-      THROW(corevm::runtime::compartment_not_found_error(compartment_id));
-    }
-
-    corevm::runtime::closure_id closure_id = frame_ptr->closure_ctx().closure_id;
-    corevm::runtime::closure closure = compartment->get_closure_by_id(closure_id);
-
-    corevm::runtime::closure_id parent_closure_id = closure.parent_id;
-
-    if (parent_closure_id == corevm::runtime::NONESET_CLOSURE_ID)
+    if (!frame_ptr)
     {
       THROW(corevm::runtime::local_variable_not_found_error());
     }
-
-    closure_ctx ctx {
-      .compartment_id = compartment_id,
-      .closure_id = parent_closure_id
-    };
-
-    process.get_frame_by_closure_ctx(ctx, &frame_ptr);
-
-    // Theoretically, the pointer that points to the frame that's
-    // associated with the parent closure should exist.
-#if __DEBUG__
-    ASSERT(frame_ptr);
-#endif
   }
 
   auto id = frame_ptr->get_visible_var(key);

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -563,8 +563,6 @@ corevm::runtime::process::start()
 
     const corevm::runtime::instr& instr = m_instrs[m_pc];
 
-    //std::cout << instr.code << " ";
-
     corevm::runtime::instr_handler* handler =
       const_cast<corevm::runtime::instr_handler*>(this->get_instr_handler(instr.code));
 
@@ -816,7 +814,9 @@ corevm::runtime::process::find_frame_by_ctx(
       break;
     }
 
-    corevm::runtime::closure closure = compartment->get_closure_by_id(ctx.closure_id);
+    corevm::runtime::closure closure = compartment->get_closure_by_id(
+      ctx.closure_id);
+
     ctx.closure_id = closure.parent_id;
 
     if (ctx.closure_id == corevm::runtime::NONESET_CLOSURE_ID)
@@ -838,7 +838,9 @@ corevm::runtime::process::find_parent_frame_in_process(
 {
   ASSERT(frame_ptr);
 
-  corevm::runtime::compartment_id compartment_id = frame_ptr->closure_ctx().compartment_id;
+  corevm::runtime::compartment_id compartment_id =
+    frame_ptr->closure_ctx().compartment_id;
+
   corevm::runtime::compartment* compartment = nullptr;
 
   process.get_compartment(compartment_id, &compartment);

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -563,6 +563,8 @@ corevm::runtime::process::start()
 
     const corevm::runtime::instr& instr = m_instrs[m_pc];
 
+    //std::cout << instr.code << " ";
+
     corevm::runtime::instr_handler* handler =
       const_cast<corevm::runtime::instr_handler*>(this->get_instr_handler(instr.code));
 
@@ -674,7 +676,7 @@ corevm::runtime::process::insert_vector(corevm::runtime::vector& vector)
 
 // -----------------------------------------------------------------------------
 
-void
+bool
 corevm::runtime::process::get_frame_by_closure_ctx(
   corevm::runtime::closure_ctx& closure_ctx, corevm::runtime::frame** frame_ptr)
 {
@@ -689,7 +691,10 @@ corevm::runtime::process::get_frame_by_closure_ctx(
   if (itr != m_call_stack.end())
   {
     *frame_ptr = &(*itr);
+    return true;
   }
+
+  return false;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/runtime/process.cc
+++ b/src/runtime/process.cc
@@ -796,6 +796,83 @@ corevm::runtime::process::reset()
 
 // -----------------------------------------------------------------------------
 
+corevm::runtime::frame*
+corevm::runtime::process::find_frame_by_ctx(
+  corevm::runtime::closure_ctx ctx,
+  corevm::runtime::compartment* compartment,
+  corevm::runtime::process& process)
+{
+  ASSERT(compartment);
+
+  corevm::runtime::frame* frame = nullptr;
+
+  while (!frame)
+  {
+    bool res = process.get_frame_by_closure_ctx(ctx, &frame);
+
+    if (res)
+    {
+      ASSERT(frame);
+      break;
+    }
+
+    corevm::runtime::closure closure = compartment->get_closure_by_id(ctx.closure_id);
+    ctx.closure_id = closure.parent_id;
+
+    if (ctx.closure_id == corevm::runtime::NONESET_CLOSURE_ID)
+    {
+      ASSERT(!frame);
+      break;
+    }
+  }
+
+  return frame;
+}
+
+// -----------------------------------------------------------------------------
+
+corevm::runtime::frame*
+corevm::runtime::process::find_parent_frame_in_process(
+  corevm::runtime::frame* frame_ptr,
+  corevm::runtime::process& process)
+{
+  ASSERT(frame_ptr);
+
+  corevm::runtime::compartment_id compartment_id = frame_ptr->closure_ctx().compartment_id;
+  corevm::runtime::compartment* compartment = nullptr;
+
+  process.get_compartment(compartment_id, &compartment);
+
+  if (!compartment)
+  {
+    THROW(corevm::runtime::compartment_not_found_error(compartment_id));
+  }
+
+  corevm::runtime::closure_id closure_id = frame_ptr->closure_ctx().closure_id;
+  corevm::runtime::closure closure = compartment->get_closure_by_id(closure_id);
+
+  corevm::runtime::closure_id parent_closure_id = closure.parent_id;
+
+  ASSERT(closure.id != closure.parent_id);
+
+  if (parent_closure_id == corevm::runtime::NONESET_CLOSURE_ID)
+  {
+    return nullptr;
+  }
+
+  closure_ctx ctx {
+    .compartment_id = compartment_id,
+    .closure_id = parent_closure_id
+  };
+
+  frame_ptr = corevm::runtime::process::find_frame_by_ctx(
+    ctx, compartment, process);
+
+  return frame_ptr;
+}
+
+// -----------------------------------------------------------------------------
+
 void
 corevm::runtime::process::unwind_stack(
   corevm::runtime::process& process, size_t limit)

--- a/src/runtime/process.h
+++ b/src/runtime/process.h
@@ -162,7 +162,7 @@ public:
 
   void insert_vector(corevm::runtime::vector& vector);
 
-  void get_frame_by_closure_ctx(
+  bool get_frame_by_closure_ctx(
     corevm::runtime::closure_ctx&, corevm::runtime::frame**);
 
   void start();

--- a/src/runtime/process.h
+++ b/src/runtime/process.h
@@ -201,6 +201,31 @@ public:
 
   void reset();
 
+  /**
+   * Given a starting closure context, find the existing frame associated with
+   * it, following the closure tree.
+   *
+   * Returns a pointer that points to the frame, if found.
+   * Returns a null pointer otherwise.
+   */
+  static
+  corevm::runtime::frame* find_frame_by_ctx(
+    corevm::runtime::closure_ctx ctx,
+    corevm::runtime::compartment* compartment,
+    corevm::runtime::process& process);
+
+  /**
+   * Given a pointer to a starting frame, find the existing frame associated
+   * with the parent of the given frame's closure context.
+   *
+   * Returns a pointer that points to the frame, if found.
+   * Returns a null pointer otherwise.
+   */
+  static
+  corevm::runtime::frame* find_parent_frame_in_process(
+    corevm::runtime::frame* frame_ptr,
+    corevm::runtime::process& process);
+
   // NOTE: Once the stack is unwinded, the action cannot be undone.
   static void unwind_stack(
     corevm::runtime::process&, size_t limit=COREVM_DEFAULT_STACK_UNWIND_COUNT);

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -643,11 +643,6 @@ TEST_F(process_find_frame_by_ctx_unittest, TestFindFrameByTraverseClosureTree)
     .closure_id = closure1.id
   };
 
-  corevm::runtime::closure_ctx ctx2 {
-    .compartment_id = 0,
-    .closure_id = closure2.id
-  };
-
   corevm::runtime::closure_ctx ctx3 {
     .compartment_id = 0,
     .closure_id = closure3.id
@@ -656,11 +651,9 @@ TEST_F(process_find_frame_by_ctx_unittest, TestFindFrameByTraverseClosureTree)
   process.insert_compartment(compartment);
 
   process.emplace_frame(ctx1);
-  process.emplace_frame(ctx2);
-  process.emplace_frame(ctx3);
 
   corevm::runtime::frame* res = corevm::runtime::process::find_frame_by_ctx(
-    ctx1, &compartment, process);
+    ctx3, &compartment, process);
 
   ASSERT_NE(nullptr, res);
   ASSERT_TRUE(ctx1 == res->closure_ctx());

--- a/tests/runtime/process_unittest.cc
+++ b/tests/runtime/process_unittest.cc
@@ -577,6 +577,306 @@ TEST_F(process_gc_rule_unittest, Test_gc_rule_by_ntvhndl_pool_size)
 
 // -----------------------------------------------------------------------------
 
+class process_find_frame_by_ctx_unittest : public process_unittest {};
+
+// -----------------------------------------------------------------------------
+
+TEST_F(process_find_frame_by_ctx_unittest, TestFindFrameWithAssociatedCtx)
+{
+  corevm::runtime::process process;
+
+  corevm::runtime::closure closure {
+    .id = 0
+  };
+
+  corevm::runtime::closure_table closure_table { closure };
+
+  corevm::runtime::compartment compartment("dummy-path");
+
+  compartment.set_closure_table(closure_table);
+
+  corevm::runtime::closure_ctx ctx {
+    .compartment_id = 0,
+    .closure_id = closure.id
+  };
+
+  process.insert_compartment(compartment);
+
+  process.emplace_frame(ctx);
+
+  corevm::runtime::frame* res = corevm::runtime::process::find_frame_by_ctx(
+    ctx, &compartment, process);
+
+  ASSERT_NE(nullptr, res);
+  ASSERT_TRUE(ctx == res->closure_ctx());
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(process_find_frame_by_ctx_unittest, TestFindFrameByTraverseClosureTree)
+{
+  corevm::runtime::process process;
+
+  corevm::runtime::closure closure1 {
+    .id = 0,
+    .parent_id = corevm::runtime::NONESET_CLOSURE_ID
+  };
+
+  corevm::runtime::closure closure2 {
+    .id = 1,
+    .parent_id = 0,
+  };
+
+  corevm::runtime::closure closure3 {
+    .id = 2,
+    .parent_id = 1,
+  };
+
+  corevm::runtime::closure_table closure_table { closure1, closure2, closure3 };
+
+  corevm::runtime::compartment compartment("dummy-path");
+
+  compartment.set_closure_table(closure_table);
+
+  corevm::runtime::closure_ctx ctx1 {
+    .compartment_id = 0,
+    .closure_id = closure1.id
+  };
+
+  corevm::runtime::closure_ctx ctx2 {
+    .compartment_id = 0,
+    .closure_id = closure2.id
+  };
+
+  corevm::runtime::closure_ctx ctx3 {
+    .compartment_id = 0,
+    .closure_id = closure3.id
+  };
+
+  process.insert_compartment(compartment);
+
+  process.emplace_frame(ctx1);
+  process.emplace_frame(ctx2);
+  process.emplace_frame(ctx3);
+
+  corevm::runtime::frame* res = corevm::runtime::process::find_frame_by_ctx(
+    ctx1, &compartment, process);
+
+  ASSERT_NE(nullptr, res);
+  ASSERT_TRUE(ctx1 == res->closure_ctx());
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(process_find_frame_by_ctx_unittest, TestFindMissingFrame)
+{
+  corevm::runtime::process process;
+
+  corevm::runtime::closure closure1 {
+    .id = 0,
+    .parent_id = corevm::runtime::NONESET_CLOSURE_ID
+  };
+
+  corevm::runtime::closure closure2 {
+    .id = 1,
+    .parent_id = 0,
+  };
+
+  corevm::runtime::closure closure3 {
+    .id = 2,
+    .parent_id = 1,
+  };
+
+  corevm::runtime::closure_table closure_table { closure1, closure2, closure3 };
+
+  corevm::runtime::compartment compartment("dummy-path");
+
+  compartment.set_closure_table(closure_table);
+
+  corevm::runtime::closure_ctx ctx1 {
+    .compartment_id = 0,
+    .closure_id = closure1.id
+  };
+
+  corevm::runtime::closure_ctx ctx2 {
+    .compartment_id = 0,
+    .closure_id = closure2.id
+  };
+
+  corevm::runtime::closure_ctx ctx3 {
+    .compartment_id = 0,
+    .closure_id = closure3.id
+  };
+
+  process.insert_compartment(compartment);
+
+  process.emplace_frame(ctx2);
+  process.emplace_frame(ctx3);
+
+  corevm::runtime::frame* res = corevm::runtime::process::find_frame_by_ctx(
+    ctx1, &compartment, process);
+
+  ASSERT_EQ(nullptr, res);
+}
+
+// -----------------------------------------------------------------------------
+
+class process_find_parent_frame_in_process_unittest : public process_unittest {};
+
+// -----------------------------------------------------------------------------
+
+TEST_F(process_find_parent_frame_in_process_unittest, TestFindParentFrameSuccessful)
+{
+  corevm::runtime::process process;
+
+  corevm::runtime::closure closure1 {
+    .id = 0,
+    .parent_id = corevm::runtime::NONESET_CLOSURE_ID
+  };
+
+  corevm::runtime::closure closure2 {
+    .id = 1,
+    .parent_id = 0,
+  };
+
+  corevm::runtime::closure closure3 {
+    .id = 2,
+    .parent_id = 1,
+  };
+
+  corevm::runtime::closure_table closure_table { closure1, closure2, closure3 };
+
+  corevm::runtime::compartment compartment("dummy-path");
+
+  compartment.set_closure_table(closure_table);
+
+  corevm::runtime::closure_ctx ctx1 {
+    .compartment_id = 0,
+    .closure_id = closure1.id
+  };
+
+  corevm::runtime::closure_ctx ctx2 {
+    .compartment_id = 0,
+    .closure_id = closure2.id
+  };
+
+  corevm::runtime::closure_ctx ctx3 {
+    .compartment_id = 0,
+    .closure_id = closure3.id
+  };
+
+  process.insert_compartment(compartment);
+
+  process.emplace_frame(ctx1);
+  process.emplace_frame(ctx2);
+  process.emplace_frame(ctx3);
+
+  corevm::runtime::frame* frame_ptr = &process.top_frame();
+
+  corevm::runtime::frame* res = corevm::runtime::process::find_parent_frame_in_process(
+    frame_ptr, process);
+
+  ASSERT_NE(nullptr, res);
+  ASSERT_TRUE(ctx2 == res->closure_ctx());
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(process_find_parent_frame_in_process_unittest, TestFindParentFrameWithMissingIntermediateFrame)
+{
+  corevm::runtime::process process;
+
+  corevm::runtime::closure closure1 {
+    .id = 0,
+    .parent_id = corevm::runtime::NONESET_CLOSURE_ID
+  };
+
+  corevm::runtime::closure closure2 {
+    .id = 1,
+    .parent_id = 0,
+  };
+
+  corevm::runtime::closure closure3 {
+    .id = 2,
+    .parent_id = 1,
+  };
+
+  corevm::runtime::closure_table closure_table { closure1, closure2, closure3 };
+
+  corevm::runtime::compartment compartment("dummy-path");
+
+  compartment.set_closure_table(closure_table);
+
+  corevm::runtime::closure_ctx ctx1 {
+    .compartment_id = 0,
+    .closure_id = closure1.id
+  };
+
+  corevm::runtime::closure_ctx ctx3 {
+    .compartment_id = 0,
+    .closure_id = closure3.id
+  };
+
+  process.insert_compartment(compartment);
+
+  process.emplace_frame(ctx1);
+  process.emplace_frame(ctx3);
+
+  corevm::runtime::frame* frame_ptr = &process.top_frame();
+
+  corevm::runtime::frame* res = corevm::runtime::process::find_parent_frame_in_process(
+    frame_ptr, process);
+
+  ASSERT_NE(nullptr, res);
+  ASSERT_TRUE(ctx1 == res->closure_ctx());
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(process_find_parent_frame_in_process_unittest, TestFindParentFrameFails)
+{
+  corevm::runtime::process process;
+
+  corevm::runtime::closure closure1 {
+    .id = 0,
+    .parent_id = corevm::runtime::NONESET_CLOSURE_ID
+  };
+
+  corevm::runtime::closure closure2 {
+    .id = 1,
+    .parent_id = 0,
+  };
+
+  corevm::runtime::closure closure3 {
+    .id = 2,
+    .parent_id = 1,
+  };
+
+  corevm::runtime::closure_table closure_table { closure1, closure2, closure3 };
+
+  corevm::runtime::compartment compartment("dummy-path");
+
+  compartment.set_closure_table(closure_table);
+
+  corevm::runtime::closure_ctx ctx3 {
+    .compartment_id = 0,
+    .closure_id = closure3.id
+  };
+
+  process.insert_compartment(compartment);
+
+  process.emplace_frame(ctx3);
+
+  corevm::runtime::frame* frame_ptr = &process.top_frame();
+
+  corevm::runtime::frame* res = corevm::runtime::process::find_parent_frame_in_process(
+    frame_ptr, process);
+
+  ASSERT_EQ(nullptr, res);
+}
+
+// -----------------------------------------------------------------------------
+
 class process_signal_handling_unittest : public process_unittest {};
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Lambda definitions and nested functions returned from parent functions do not work.

The following example:

```
def parent():
    def inner():
        raise Exception()
 
    return inner

parent()()
```

will cause the VM to hang forever.


----


While the following examples will hit a "closure not found" assertion:

```
def parent():
    def inner():
        raise Exception()
 
    return inner

inner = parent()
inner()
```

```
def lambda_caller():
    def inner(arg):
        func = lambda arg: arg ** arg
        return fun

    return inner

lambda_caller()(5)
```

---

**ROOT CAUSE**:

The root of the observed phenomena is a combination of causes, that occured in both the VM as well as the Python compiler.

**Issue in compiler**:

Nested functions with the same name were mapped to the same closure, since the compiler did not take into account using the fully quantitied location of nested functions to unique identify them and associate them with distinct closures. Therefore, once a nested function with a name has been associated with a closure in the compiler, subsequent functions (nested or not) will be mapped to the wrong closure contexts.

The solution is to use the fully quantified locations (full class chain path + full function chain path) of functions to uniquely identify them.

**Issue in coreVM**:

Previously in the `ldobj`, `ldobj`, and `cldobj` instructions. Variable lookup were following the process's call stack, from top to bottom. However, this won't work with returned nested functions or lambdas, because their parent frames do not exist in the process anymore once they are returned (a.k.a their parent frames will be popped).

Example:

```
MY_NAME = 'Will'

def run():
	def inner():
		return MY_NAME
	return inner

print run()()
```

The closure tree formed based on the code above will assemble the following form:

- closure (0)          <- `__main__`
    - closure (1)      <- `run`
        - closure (2)  <- `inner`

The problem is that once `inner()` is returned from `run()`, the frame associated with `run()` will no longer exist in the process, so the top-to-bottom frame look up approach will never hit the frame associated with `__main__`.

The solution is to do parent frame lookup in the process following the closure tree hierarchy, instead of following the call stack from top to bottom.