### PR TITLE
[COREVM-229] Support Python try-except-else

### DIFF
--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -272,6 +272,17 @@ class CodeTransformer(ast.NodeVisitor):
         for handler in node.handlers:
             base_str += self.visit(handler)
 
+        if node.orelse:
+            base_str += '{indentation}else:\n'.format(
+                indentation=self.__indentation())
+
+            self.__indent()
+
+            for stmt in node.orelse:
+                base_str += self.visit(stmt)
+
+            self.__dedent()
+
         return base_str
 
     def visit_Expr(self, node):

--- a/python/code_transformer.py
+++ b/python/code_transformer.py
@@ -557,7 +557,7 @@ class CodeTransformer(ast.NodeVisitor):
             elif node.name:
                 return ' {name}'.format(name=self.visit(node.name))
             else:
-                return ''
+                return ' {type}'.format(type='Exception')
 
         base_str = '{indentation}except{type_and_name}:\n'.format(
             indentation=self.__indentation(),

--- a/python/tests/try_except.py
+++ b/python/tests/try_except.py
@@ -162,6 +162,30 @@ else:
 
 ## -----------------------------------------------------------------------------
 
+def raise_another_exception():
+    raise AnotherException()
+
+try:
+    raise_another_exception()
+except AnotherException:
+    print 'AnotherException caught'
+else:
+    print 'This should not be printed'
+
+## -----------------------------------------------------------------------------
+
+def run():
+    parent()()
+
+try:
+    run()
+except:
+    print 'Exception caught'
+else:
+    print 'This should not be printed'
+
+## -----------------------------------------------------------------------------
+
 # TODO: Run this test when inheritance is supported.
 #try:
 #    raise YetAnotherException()

--- a/python/tests/try_except.py
+++ b/python/tests/try_except.py
@@ -144,6 +144,24 @@ except Exception:
 
 ## -----------------------------------------------------------------------------
 
+try:
+    print 'Do something here...'
+except YetAnotherException:
+    print 'This is not the right exception'
+else:
+    print 'This should be printed'
+
+## -----------------------------------------------------------------------------
+
+try:
+    raise AnotherException()
+except AnotherException:
+    print 'This should be printed'
+else:
+    print 'This should not be printed'
+
+## -----------------------------------------------------------------------------
+
 # TODO: Run this test when inheritance is supported.
 #try:
 #    raise YetAnotherException()

--- a/src/runtime/frame.cc
+++ b/src/runtime/frame.cc
@@ -260,6 +260,14 @@ corevm::runtime::frame::closure_ctx() const
 
 // -----------------------------------------------------------------------------
 
+corevm::dyobj::dyobj_id
+corevm::runtime::frame::exc_obj() const
+{
+  return m_exc_obj;
+}
+
+// -----------------------------------------------------------------------------
+
 void
 corevm::runtime::frame::set_exc_obj(corevm::dyobj::dyobj_id exc_obj)
 {
@@ -268,10 +276,10 @@ corevm::runtime::frame::set_exc_obj(corevm::dyobj::dyobj_id exc_obj)
 
 // -----------------------------------------------------------------------------
 
-corevm::dyobj::dyobj_id
-corevm::runtime::frame::exc_obj() const
+void
+corevm::runtime::frame::clear_exc_obj()
 {
-  return m_exc_obj;
+  m_exc_obj = 0;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/runtime/frame.h
+++ b/src/runtime/frame.h
@@ -98,9 +98,11 @@ public:
 
   corevm::runtime::closure_ctx closure_ctx() const;
 
+  corevm::dyobj::dyobj_id exc_obj() const;
+
   void set_exc_obj(corevm::dyobj::dyobj_id exc_obj);
 
-  corevm::dyobj::dyobj_id exc_obj() const;
+  void clear_exc_obj();
 
 protected:
   const corevm::runtime::closure_ctx m_closure_ctx;

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -172,7 +172,7 @@ corevm::runtime::instr_handler_meta::instr_set[INSTR_CODE_MAX] {
   /* EXC       */    { .num_oprd=0, .str="exc",       .handler=std::make_shared<corevm::runtime::instr_handler_exc>()       },
   /* EXCOBJ    */    { .num_oprd=0, .str="excobj",    .handler=std::make_shared<corevm::runtime::instr_handler_excobj>()    },
   /* CLREXC    */    { .num_oprd=0, .str="clrexc",    .handler=std::make_shared<corevm::runtime::instr_handler_clrexc>()    },
-  /* JMPEXC    */    { .num_oprd=1, .str="jmpexc",    .handler=std::make_shared<corevm::runtime::instr_handler_jmpexc>()    },
+  /* JMPEXC    */    { .num_oprd=2, .str="jmpexc",    .handler=std::make_shared<corevm::runtime::instr_handler_jmpexc>()    },
   /* EXIT      */    { .num_oprd=1, .str="exit",      .handler=std::make_shared<corevm::runtime::instr_handler_exit>()      },
 
   /* ------------------------- Function instructions ------------------------ */

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -1409,12 +1409,6 @@ void
 corevm::runtime::instr_handler_exit::execute(
   const corevm::runtime::instr& instr, corevm::runtime::process& process)
 {
-  /*
-  // http://en.cppreference.com/w/cpp/utility/program/exit
-  int exit_code = static_cast<int>(instr.oprd1);
-  std::cout << "Exiting program with code " << exit_code << ". Bye." << std::endl;
-  std::exit(exit_code);
-  */
   raise(SIGTERM);
 }
 

--- a/src/runtime/instr.cc
+++ b/src/runtime/instr.cc
@@ -171,6 +171,8 @@ corevm::runtime::instr_handler_meta::instr_set[INSTR_CODE_MAX] {
   /* JMPR      */    { .num_oprd=1, .str="jmpr",      .handler=std::make_shared<corevm::runtime::instr_handler_jmpr>()      },
   /* EXC       */    { .num_oprd=0, .str="exc",       .handler=std::make_shared<corevm::runtime::instr_handler_exc>()       },
   /* EXCOBJ    */    { .num_oprd=0, .str="excobj",    .handler=std::make_shared<corevm::runtime::instr_handler_excobj>()    },
+  /* CLREXC    */    { .num_oprd=0, .str="clrexc",    .handler=std::make_shared<corevm::runtime::instr_handler_clrexc>()    },
+  /* JMPEXC    */    { .num_oprd=1, .str="jmpexc",    .handler=std::make_shared<corevm::runtime::instr_handler_jmpexc>()    },
   /* EXIT      */    { .num_oprd=1, .str="exit",      .handler=std::make_shared<corevm::runtime::instr_handler_exit>()      },
 
   /* ------------------------- Function instructions ------------------------ */
@@ -1354,6 +1356,50 @@ corevm::runtime::instr_handler_excobj::execute(
   else
   {
     process.push_stack(exc_obj_id);
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::instr_handler_clrexc::execute(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  corevm::runtime::frame& frame = process.top_frame();
+  frame.clear_exc_obj();
+}
+
+// -----------------------------------------------------------------------------
+
+void
+corevm::runtime::instr_handler_jmpexc::execute(
+  const corevm::runtime::instr& instr, corevm::runtime::process& process)
+{
+  const corevm::runtime::frame& frame = process.top_frame();
+  corevm::dyobj::dyobj_id exc_obj_id = frame.exc_obj();
+
+  bool jump_on_exc = static_cast<bool>(instr.oprd2);
+
+  bool jump = jump_on_exc ? exc_obj_id : !exc_obj_id;
+
+  if (jump)
+  {
+    corevm::runtime::instr_addr starting_addr = process.pc();
+    corevm::runtime::instr_addr relative_addr =
+      static_cast<corevm::runtime::instr_addr>(instr.oprd1);
+
+    corevm::runtime::instr_addr addr = starting_addr + relative_addr;
+
+    if (addr == corevm::runtime::NONESET_INSTR_ADDR)
+    {
+      THROW(corevm::runtime::invalid_instr_addr_error());
+    }
+    else if (addr < starting_addr)
+    {
+      THROW(corevm::runtime::invalid_instr_addr_error());
+    }
+
+    process.set_pc(addr);
   }
 }
 

--- a/src/runtime/instr.h
+++ b/src/runtime/instr.h
@@ -300,6 +300,25 @@ enum instr_enum : uint32_t
   EXCOBJ,
 
   /**
+   * <clrexc, _, _>
+   * Clears the exception object associated with the frame on top of the call
+   * stack.
+   */
+  CLREXC,
+
+  /**
+   * <jmpexc, #, #>
+   * Jumps to the specified address, based on the state of the exception object
+   * associated with the frame on top of the call stack.
+   * The first operand is the number of addresses to jump over starting from
+   * the current program counter.
+   * The second operand specifies whether or not to jump based on if the top of
+   * stack frame has an exception object. A value of `1` specifies the jump
+   * if the frame has an exception object, `0` otherwise.
+   */
+  JMPEXC,
+
+  /**
    * <exit, code, _>
    * Halts the execution of instructions and exits the program
    * (with an optional exit code).
@@ -1379,6 +1398,22 @@ public:
 // -----------------------------------------------------------------------------
 
 class instr_handler_excobj : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_clrexc : public instr_handler
+{
+public:
+  virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);
+};
+
+// -----------------------------------------------------------------------------
+
+class instr_handler_jmpexc : public instr_handler
 {
 public:
   virtual void execute(const corevm::runtime::instr&, corevm::runtime::process&);

--- a/tests/runtime/frame_unittest.cc
+++ b/tests/runtime/frame_unittest.cc
@@ -42,6 +42,7 @@ TEST_F(frame_unittest, TestInitialization)
 {
   corevm::runtime::frame frame(m_closure_ctx);
   ASSERT_EQ(corevm::runtime::NONESET_INSTR_ADDR, frame.return_addr());
+  ASSERT_EQ(0, frame.exc_obj());
 }
 
 // -----------------------------------------------------------------------------
@@ -144,6 +145,24 @@ TEST_F(frame_unittest, TestInvisibleVars)
     },
     corevm::runtime::local_variable_not_found_error
   );
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(frame_unittest, TestGetAndSetExcObj)
+{
+  corevm::runtime::frame frame(m_closure_ctx);
+  corevm::dyobj::dyobj_id id = 1;
+
+  ASSERT_NE(id, frame.exc_obj());
+
+  frame.set_exc_obj(id);
+
+  ASSERT_EQ(id, frame.exc_obj());
+
+  frame.clear_exc_obj();
+
+  ASSERT_EQ(0, frame.exc_obj());
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/runtime/instrs_unittest.cc
+++ b/tests/runtime/instrs_unittest.cc
@@ -1662,6 +1662,85 @@ TEST_F(instrs_obj_unittest, TestInstrEXCOBJ)
 
 // -----------------------------------------------------------------------------
 
+TEST_F(instrs_control_instrs_test, TestInstrCLREXC)
+{
+  corevm::runtime::closure_ctx ctx {
+    .closure_id = 0,
+    .compartment_id = 0
+  };
+
+  corevm::runtime::frame frame(ctx);
+
+  ASSERT_EQ(0, frame.exc_obj());
+
+  corevm::dyobj::dyobj_id id = 1;
+
+  frame.set_exc_obj(id);
+
+  ASSERT_EQ(id, frame.exc_obj());
+
+  m_process.push_frame(frame);
+
+  corevm::runtime::instr instr {
+    .code = 0,
+    .oprd1 = 0,
+    .oprd2 = 0
+  };
+
+  corevm::runtime::instr_handler_clrexc handler;
+  handler.execute(instr, m_process);
+
+  corevm::runtime::frame& actual_frame = m_process.top_frame();
+
+  ASSERT_EQ(0, actual_frame.exc_obj());
+}
+
+// -----------------------------------------------------------------------------
+
+TEST_F(instrs_control_instrs_test, TestInstrJMPEXC)
+{
+  const corevm::runtime::closure_id closure_id = 0;
+  const corevm::runtime::compartment_id compartment_id = 0;
+
+  corevm::runtime::vector vector {
+    { 0, 0, 0 },
+    { 0, 0, 0 },
+    { 0, 0, 0 },
+    { 0, 0, 0 },
+    { 0, 0, 0 },
+    { 0, 0, 0 },
+    { 0, 0, 0 },
+  };
+
+  corevm::runtime::closure_ctx ctx {
+    .closure_id = closure_id,
+    .compartment_id = compartment_id
+  };
+
+  corevm::dyobj::dyobj_id id = 1;
+
+  corevm::runtime::frame frame(ctx);
+  frame.set_exc_obj(id);
+  m_process.push_frame(frame);
+
+  // Emulate process starting condition.
+  m_process.insert_vector(vector);
+  m_process.set_pc(0);
+
+  corevm::runtime::instr instr {
+    .code = 0,
+    .oprd1 = 6,
+    .oprd2 = 1
+  };
+
+  corevm::runtime::instr_handler_jmpexc handler;
+  handler.execute(instr, m_process);
+
+  ASSERT_EQ(6, m_process.pc());
+}
+
+// -----------------------------------------------------------------------------
+
 TEST_F(instrs_control_instrs_test, TestInstrEXIT)
 {
   auto sig_handler = [](int signum) {


### PR DESCRIPTION
This patch adds the support for the `try-except-else` semantics in Python, following the work done in #150.

This patch adds the support by making use of two new instructions: `clrexc` and `jmpexc`. Those two instructions provides the capability to determine whether an exception object is associated with the current frame, and switch control by jumping to a destination address accordingly. This is needed to implement the `try-except-else` semantics because we need to be able to determine whether or not an exception has been raised.

The `clrexc` instruction addresses a missed logic in #150, which is that once the exception has been handled, the exception object has to be cleared from the current frame.